### PR TITLE
Hotfix/export profile multi stop

### DIFF
--- a/dataDownloader/csvhelper/helper.py
+++ b/dataDownloader/csvhelper/helper.py
@@ -153,6 +153,7 @@ class CSVHelper:
                 elif field in ['halfHourInStartTime', 'halfHourInStopTime', 'mediahora_bajada_1',
                                'mediahora_bajada_2', 'mediahora_bajada_3', 'mediahora_bajada_4']:
                     values = [self.halfhour_dict[int(x)] for x in values]
+                field = 'authStopCode' if field == 'authStopCode.raw' else field
 
                 formatted_values = []
                 for value in values:

--- a/esapi/static/js/filterManager.js
+++ b/esapi/static/js/filterManager.js
@@ -211,7 +211,6 @@ function FilterManager(opts) {
     }
     let localMultiStopFilterVal = JSON.parse(window.localStorage.getItem(urlKey + "multiStopFilter/val")) || "";
     let localMultiStopFilterText = JSON.parse(window.localStorage.getItem(urlKey + "multiStopFilter/text")) || "";
-    localMultiStopFilterText = localMultiStopFilterText !== "" ? localMultiStopFilterText : "";
     for (let i = 0; i < localMultiStopFilterText.length; i++) {
         let multi_option = new Option(localMultiStopFilterText[i], localMultiStopFilterVal[i], false, true);
         $MULTI_STOP_FILTER.append(multi_option);

--- a/esapi/static/js/filterManager.js
+++ b/esapi/static/js/filterManager.js
@@ -211,7 +211,7 @@ function FilterManager(opts) {
     }
     let localMultiStopFilterVal = JSON.parse(window.localStorage.getItem(urlKey + "multiStopFilter/val")) || "";
     let localMultiStopFilterText = JSON.parse(window.localStorage.getItem(urlKey + "multiStopFilter/text")) || "";
-    localMultiStopFilterText = localMultiStopFilterText !== "" ? localMultiStopFilterText.split("\n") : "" ;
+    localMultiStopFilterText = localMultiStopFilterText !== "" ? localMultiStopFilterText : "";
     for (let i = 0; i < localMultiStopFilterText.length; i++) {
         let multi_option = new Option(localMultiStopFilterText[i], localMultiStopFilterVal[i], false, true);
         $MULTI_STOP_FILTER.append(multi_option);
@@ -220,7 +220,8 @@ function FilterManager(opts) {
 
     $MULTI_STOP_FILTER.change(function () {
         window.localStorage.setItem(urlKey + "multiStopFilter/val", JSON.stringify($MULTI_STOP_FILTER.val()));
-        window.localStorage.setItem(urlKey + "multiStopFilter/text", JSON.stringify($MULTI_STOP_FILTER[0].innerText));
+        let textOptions = [...$MULTI_STOP_FILTER[0].selectedOptions].map(e => e.innerText);
+        window.localStorage.setItem(urlKey + "multiStopFilter/text", JSON.stringify(textOptions));
     });
     /* BUTTON ACTION */
     var getParameters = function () {


### PR DESCRIPTION
- Para el bug de exporter se corrige el término authStopCode.raw por authStopCode al momento de generar los textos descriptivos (no afecta la consulta).
- Para el bug del filtro se cambió el valor a almacenar en localStorage, siendo un arreglo de los textos del input. Esto se hizo debido a que antes al cambiar los paraderos no se actualizaba correctamente en localStorage.