### PR TITLE
Bug Perfil de Carga -> Trayectoria

### DIFF
--- a/esapi/helper/profile.py
+++ b/esapi/helper/profile.py
@@ -210,7 +210,7 @@ class ESProfileHelper(ElasticSearchHelper):
             ['busCapacity', 'licensePlate', 'route', 'loadProfile', 'expeditionDayId', 'expandedAlighting',
              'expandedBoarding', 'expeditionStartTime', 'expeditionEndTime', 'authStopCode', 'timePeriodInStartTime',
              'dayType', 'timePeriodInStopTime', 'busStation', 'path', 'stopDistanceFromPathStart',
-             'expeditionStopTime'])
+             'expeditionStopTime', 'notValid'])
 
         return es_query
 

--- a/esapi/tests/testProfileIndex.py
+++ b/esapi/tests/testProfileIndex.py
@@ -169,16 +169,17 @@ class ESProfileIndexTest(TestCase):
         result = self.instance.get_base_profile_by_trajectory_data_query(dates, day_type, auth_route,
                                                                          period, half_hour,
                                                                          valid_operator_list)
-        expected = {'query': {'bool': {'filter': [{'terms': {'operator': [1, 2, 3]}}, {'term': {'route': u'506 00I'}},
-                                                  {'terms': {'dayType': [u'LABORAL']}},
+        expected = {'query': {'bool': {'filter': [{'terms': {'operator': [1, 2, 3]}}, {'term': {'route': '506 00I'}},
+                                                  {'terms': {'dayType': ['LABORAL']}},
                                                   {'terms': {'timePeriodInStartTime': [1, 2, 3]}},
                                                   {'terms': {'halfHourInStartTime': [1, 2, 3]}}, {'range': {
-                'expeditionStartTime': {u'time_zone': u'+00:00', u'gte': u'2018-01-01||/d', u'lte': u'2018-01-02||/d',
-                                        u'format': u'yyyy-MM-dd'}}}]}},
-                    '_source': [u'busCapacity', u'licensePlate', u'route', u'loadProfile', u'expeditionDayId',
-                                u'expandedAlighting', u'expandedBoarding', u'expeditionStartTime', u'expeditionEndTime',
-                                u'authStopCode', u'timePeriodInStartTime', u'dayType', u'timePeriodInStopTime',
-                                u'busStation', u'path', u'stopDistanceFromPathStart', u'expeditionStopTime']}
+                'expeditionStartTime': {'gte': '2018-01-01||/d', 'lte': '2018-01-02||/d', 'format': 'yyyy-MM-dd',
+                                        'time_zone': '+00:00'}}}]}},
+                    '_source': ['busCapacity', 'licensePlate', 'route', 'loadProfile', 'expeditionDayId',
+                                'expandedAlighting', 'expandedBoarding', 'expeditionStartTime', 'expeditionEndTime',
+                                'authStopCode', 'timePeriodInStartTime', 'dayType', 'timePeriodInStopTime',
+                                'busStation', 'path', 'stopDistanceFromPathStart', 'expeditionStopTime', 'notValid']}
+
         self.assertIsInstance(result, Search)
         self.assertDictEqual(result.to_dict(), expected)
 

--- a/esapi/views/profile.py
+++ b/esapi/views/profile.py
@@ -289,7 +289,7 @@ class LoadProfileByTrajectoryData(View):
                     'dayType': day_type_dict[hit.dayType],
                     'valid': not bool(hit.notValid)
                 }
-                if not bool(hit.notValid):
+                if bool(hit.notValid):
                     expedition_not_valid_number += 1
 
             if hit.busStation == 1 and hit.authStopCode not in bus_stations:

--- a/esapi/views/profile.py
+++ b/esapi/views/profile.py
@@ -276,11 +276,9 @@ class LoadProfileByTrajectoryData(View):
 
         day_type_dict = get_day_type_list_for_select_input(to_dict=True)
         time_period_dict = get_timeperiod_list_for_select_input(to_dict=True)
-        print(es_query)
         for hit in es_query.scan():
             expedition_id = '{0}-{1}'.format(hit.path, hit.expeditionDayId)
             if 'capacity' not in trips[expedition_id]['info']:
-                print(hit.to_dict())
                 trips[expedition_id]['info'] = {
                     'capacity': hit.busCapacity,
                     'licensePlate': hit.licensePlate,

--- a/esapi/views/profile.py
+++ b/esapi/views/profile.py
@@ -276,9 +276,11 @@ class LoadProfileByTrajectoryData(View):
 
         day_type_dict = get_day_type_list_for_select_input(to_dict=True)
         time_period_dict = get_timeperiod_list_for_select_input(to_dict=True)
+        print(es_query)
         for hit in es_query.scan():
             expedition_id = '{0}-{1}'.format(hit.path, hit.expeditionDayId)
             if 'capacity' not in trips[expedition_id]['info']:
+                print(hit.to_dict())
                 trips[expedition_id]['info'] = {
                     'capacity': hit.busCapacity,
                     'licensePlate': hit.licensePlate,
@@ -287,9 +289,9 @@ class LoadProfileByTrajectoryData(View):
                     'timeTripInit': hit.expeditionStartTime.replace('T', ' ').replace('.000Z', ''),
                     'timeTripEnd': hit.expeditionEndTime.replace('T', ' ').replace('.000Z', ''),
                     'dayType': day_type_dict[hit.dayType],
-                    'valid': bool(hit.isValid)
+                    'valid': not bool(hit.notValid)
                 }
-                if not hit.isValid:
+                if not bool(hit.notValid):
                     expedition_not_valid_number += 1
 
             if hit.busStation == 1 and hit.authStopCode not in bus_stations:


### PR DESCRIPTION
El problema que sucedía era que se estaba utilizando un parámetro equivocado para comprobar si un viaje era válido o no, es decir, se estaba utilizando hit.isValid siendo que en el mapping elasticsearch de profile el parámetro es notValid.

Además de esto, no pasaba por los test debido a que en los tests no se estaba considerando el uso de ese parámetro. Esto se debe a que anteriormente el parámetro isValid se calculaba de forma random y cuando se modificaron los tests, se agregó el test correspondiente en esapi/views/profile.py y no se consideró en  esapi/helper/profile.py.

Se corrige el uso del parámetro y se agregan los test correspondientes.