### PR TITLE
Cambio en selector para ficha de servicios

### DIFF
--- a/esapi/views/shape.py
+++ b/esapi/views/shape.py
@@ -10,7 +10,8 @@ from esapi.errors import FondefVizError, ESQueryRouteParameterDoesNotExist, ESQu
 from esapi.helper.shape import ESShapeHelper
 from esapi.helper.stopbyroute import ESStopByRouteHelper
 from esapi.helper.profile import ESProfileHelper
-from localinfo.helper import PermissionBuilder, get_valid_time_period_date, get_timeperiod_list_for_select_input, get_periods_dict
+from localinfo.helper import PermissionBuilder, get_valid_time_period_date, get_timeperiod_list_for_select_input, \
+    get_periods_dict, get_op_routes_dict
 
 
 class GetRouteInfo(View):
@@ -70,12 +71,14 @@ class GetBaseInfo(View):
         for key in available_routes:
             for value in available_routes[key]:
                 user_routes[value] = available_routes[key][value]
+        op_routes_dict = get_op_routes_dict()
         response = {
             'dates': dates,
             'routes': routes,
             'user_routes': user_routes,
             'dates_periods_dict': dates_periods_dict,
-            'periods': periods
+            'periods': periods,
+            'op_routes_dict': op_routes_dict
         }
 
         return JsonResponse(response)

--- a/esapi/views/shape.py
+++ b/esapi/views/shape.py
@@ -71,7 +71,7 @@ class GetBaseInfo(View):
         for key in available_routes:
             for value in available_routes[key]:
                 user_routes[value] = available_routes[key][value]
-        op_routes_dict = get_op_routes_dict()
+        op_routes_dict = get_op_routes_dict(key='auth_route_code', answer='op_route_code')
         response = {
             'dates': dates,
             'routes': routes,

--- a/localinfo/helper.py
+++ b/localinfo/helper.py
@@ -131,15 +131,15 @@ def get_op_route(auth_route_code):
     return res
 
 
-def get_op_routes_dict():
+def get_op_routes_dict(key='auth_route_code', answer='route_type'):
     """
-    :return: dict {auth_route_code: route_type}
+    :return: dict {key: answer}
     """
     op_program_dict = get_opprogram_list_for_select_input(to_dict=True)
     routes_dict = defaultdict(lambda: defaultdict(list))
-    for auth_route_code, route_type, op_program in OPDictionary.objects.values_list('auth_route_code', 'route_type',
-                                                                                    'op_program_id'):
-        routes_dict[op_program_dict[op_program]][auth_route_code].append(route_type)
+    for op_key, op_answer, op_program in OPDictionary.objects.values_list(key, answer,
+                                                                          'op_program_id'):
+        routes_dict[op_program_dict[op_program]][op_key].append(op_answer)
     return routes_dict
 
 

--- a/shape/static/shape/css/mapBase.css
+++ b/shape/static/shape/css/mapBase.css
@@ -86,7 +86,7 @@
 }
 
 .route {
-    width: 120px !important;
+    width: 180px !important;
 }
 
 .period {

--- a/shape/static/shape/js/mapApp.js
+++ b/shape/static/shape/js/mapApp.js
@@ -105,12 +105,21 @@ $(document).ready(function () {
                 let selector = $(this).closest(".selectorRow");
                 let userRoute = selector.find(".userRoute").first().val();
                 let route = selector.find(".route").first();
+                let date = selector.find(".date").first().val();
 
                 //update authroute list
                 let routeValues = _self.data[userRoute];
                 route.empty();
-                route.append(routeValues.map(e => '<option>' + e + '</option>').join(""));
-
+                route.select2({
+                    data: routeValues.map(e => {
+                        let text = _self.op_routes_dict[date][e] || e;
+                        text = text === e ? e : `${text} (${e})`;
+                        return {
+                            id: e,
+                            text: text
+                        }
+                    })
+                });
                 //set value
                 let allSelectors = $(".selectorRow");
                 let selectorIndex = allSelectors.index(selector);
@@ -388,6 +397,7 @@ $(document).ready(function () {
                 // data for selectors
                 _self.data = data.user_routes;
                 _self.dates_period_dict = data.dates_periods_dict;
+                _self.op_routes_dict = data.op_routes_dict;
                 _self.periods = data.periods;
                 let userRouteList = Object.keys(data.user_routes).map(e =>
                     "<option>" + e + "</option>"


### PR DESCRIPTION
Rama basada en pull request #74
- A la vista shape se le envía un diccionario con las llaves {fecha_op: {ruta_transantiago: ruta_operación, ... } }
- Al js mapApp se le modifica el selector de ruta transantiago: se le cambia el texto de 'ruta transantiago' a 'ruta operación (ruta trasantiago).
- Al css custom.css se le ajusta el tamaño nuevo del selector.