### PR TITLE
Bug al seleccionar fechas

### DIFF
--- a/consistencychecker/management/commands/checkopprogramconsistency.py
+++ b/consistencychecker/management/commands/checkopprogramconsistency.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
                 except ESQueryStopListDoesNotExist:
                     dates[date]['stop']['missing'].append(auth_route_code)
 
-                op_route_code = helper.get_op_route(auth_route_code)
+                op_route_code = helper.get_op_route(auth_route_code, date)
                 try:
                     data_list = opdata_helper.get_route_info(op_route_code, [[date]])
                 except ESQueryRouteParameterDoesNotExist:

--- a/consistencychecker/tests/testCheckopprogramconsistency.py
+++ b/consistencychecker/tests/testCheckopprogramconsistency.py
@@ -5,6 +5,7 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from esapi.errors import ESQueryStopListDoesNotExist, ESQueryRouteParameterDoesNotExist
+from localinfo.models import OPProgram
 
 
 class CheckopprogramconsistencyTest(TestCase):
@@ -31,6 +32,7 @@ class CheckopprogramconsistencyTest(TestCase):
     @mock.patch('consistencychecker.management.commands.checkopprogramconsistency.ESStopByRouteHelper')
     def test_command_output_missing_authcode_in_stop(self, stopbyroute_helper, stop_helper, shape_helper,
                                                      opdata_helper):
+        self.op_program = OPProgram.objects.create(valid_from='2020-05-03')
         shape_helper.return_value.get_available_days.return_value = ['2020-05-03']
         opdata_helper.return_value.get_available_days.return_value = ['2020-05-03']
         stop_helper.return_value.get_available_days.return_value = ['2020-05-03']
@@ -52,6 +54,7 @@ class CheckopprogramconsistencyTest(TestCase):
     def test_command_output_missing_authcode_in_opdata(self, stopbyroute_helper, stop_helper, shape_helper,
                                                        opdata_helper,
                                                        helper):
+        self.op_program = OPProgram.objects.create(valid_from='2020-05-03')
         shape_helper.return_value.get_available_days.return_value = ['2020-05-03']
         opdata_helper.return_value.get_available_days.return_value = ['2020-05-03']
         stop_helper.return_value.get_available_days.return_value = ['2020-05-03']

--- a/esapi/static/js/filterManager.js
+++ b/esapi/static/js/filterManager.js
@@ -135,7 +135,6 @@ function FilterManager(opts) {
 
     const getOPDictBetweenDates = () => {
         let dates = getDates();
-        console.log(dates);
         if (dates.length === 0) {
             return 0;
         }

--- a/esapi/static/js/filterManager.js
+++ b/esapi/static/js/filterManager.js
@@ -135,12 +135,14 @@ function FilterManager(opts) {
 
     const getOPDictBetweenDates = () => {
         let dates = getDates();
+        console.log(dates);
         if (dates.length === 0) {
             return 0;
         }
         let routesDict = operatorFilterData["routesDict"];
-        let firstDate = new Date(dates[0]);
-        let lastDate = new Date(dates.slice(-1).pop());
+        let firstDate = new Date(dates[0][0]);
+        let lastIndex = dates.length - 1;
+        let lastDate = new Date(dates[lastIndex][dates[lastIndex].length - 1]);
         let routesDictKeys = Object.keys(routesDict).sort();
         let periodDateValid = null;
         for (const date of routesDictKeys) {

--- a/esapi/tests/testOpDataView.py
+++ b/esapi/tests/testOpDataView.py
@@ -35,7 +35,7 @@ class OPDataByAuthRouteCode(TestHelper):
         self.assertJSONEqual(status, ESQueryDateParametersDoesNotExist().get_status_response())
 
     def test_wrong_auth_code(self):
-        self.data['dates'] = '[["2020-03-05"]]'
+        self.data['dates'] = '[["2020-01-01"]]'
         self.data['authRouteCode'] = '100000'
         response = self.client.get(self.url, self.data)
         status = json.dumps(json.loads(response.content)['status'])
@@ -47,7 +47,7 @@ class OPDataByAuthRouteCode(TestHelper):
         helper.get_route_info.return_value = helper
         unsorted_dict = [AttrDict({'timePeriod': 2}), AttrDict({'timePeriod': 1})]
         helper.execute.return_value = [AttrDict({'dayType': AttrList(unsorted_dict)})]
-        self.data['dates'] = '[["2020-03-05"]]'
+        self.data['dates'] = '[["2020-01-01"]]'
         self.data['authRouteCode'] = 'T101 00I'
         response = self.client.get(self.url, self.data)
         expected_dict = '{"1": {"timePeriod": "Pre nocturno (00:00:00-00:59:59)"}, "2": {"timePeriod": "Nocturno (01:00:00-05:29:59)"}}'

--- a/esapi/views/opdata.py
+++ b/esapi/views/opdata.py
@@ -39,7 +39,7 @@ class OPDataByAuthRouteCode(View):
             if not dates or not isinstance(dates[0], list) or not dates[0]:
                 raise ESQueryDateParametersDoesNotExist
 
-            code = get_op_route(auth_code)
+            code = get_op_route(auth_code, dates[0][0])
             if not code:
                 raise ESQueryAuthRouteCodeTranslateDoesNotExist(auth_code)
 

--- a/localinfo/helper.py
+++ b/localinfo/helper.py
@@ -119,13 +119,14 @@ def search_faq(searchText):
     return grouped
 
 
-def get_op_route(auth_route_code):
+def get_op_route(auth_route_code, date):
     """
     :param auth_route_code:
     :return: op_route_code matched with auth_route_code
     """
+    op_program_id = OPProgram.objects.get(valid_from=date)
     try:
-        res = OPDictionary.objects.get(auth_route_code=auth_route_code).op_route_code
+        res = OPDictionary.objects.get(auth_route_code=auth_route_code, op_program=op_program_id).op_route_code
     except OPDictionary.DoesNotExist:
         return None
     return res

--- a/localinfo/tests/testHelper.py
+++ b/localinfo/tests/testHelper.py
@@ -37,14 +37,20 @@ class TestHelperUtils(TestCase):
     def test_get_op_route(self):
         auth_code = 'T101 00I'
         op_code = '101I'
-        op_program = OPProgram.objects.create(valid_from='2020-01-01')
+        date = '2020-01-01'
+        op_program = OPProgram.objects.create(valid_from=date)
         OPDictionary.objects.create(auth_route_code=auth_code, op_route_code=op_code, op_program=op_program)
-        query = get_op_route(auth_code)
+        query = get_op_route(auth_code, date)
         self.assertEqual(op_code, query)
         op_program.delete()
 
     def test_get_op_route_wrong_code(self):
-        self.assertIsNone(get_op_route('T0000'))
+        auth_code = 'T101 00I'
+        op_code = '101I'
+        date = '2020-01-01'
+        op_program = OPProgram.objects.create(valid_from=date)
+        OPDictionary.objects.create(auth_route_code=auth_code, op_route_code=op_code, op_program=op_program)
+        self.assertIsNone(get_op_route('T0000', '2020-01-01'))
 
     def test__list_parser(self):
         test_list = [[1, 2], [3, 4]]

--- a/shape/static/shape/js/mapApp.js
+++ b/shape/static/shape/js/mapApp.js
@@ -174,6 +174,7 @@ $(document).ready(function () {
                 //update periods list
                 let periodValues = _self.periods[_self.dates_period_dict[date]];
                 periods.empty();
+                periods.append("<option value=0>Todos</option>");
                 periods.append(periodValues.map(e => `<option value=${e.value}>` + e.item + '</option>').join(""));
 
                 //set value
@@ -321,6 +322,7 @@ $(document).ready(function () {
                     decimal: ",",
                     thousands: "."
                 },
+                pageLength: 30,
                 retrieve: true,
                 orderable: false,
                 dom: 'Brt',
@@ -375,11 +377,12 @@ $(document).ready(function () {
                         $INFOMODAL.on('shown.bs.modal', function () {
                             let $TABLE = $('#shapeDetail').DataTable();
                             $TABLE.clear();
-                            if (period === 0) {
-                                data.data.forEach(function (e) {
-                                        $TABLE.rows.add(e)
-                                    }
-                                )
+                            console.log(period);
+                            if (period === "0") {
+                                for (const [key, value] of Object.entries(data.data)) {
+                                    console.log(value);
+                                    $TABLE.rows.add([value]);
+                                }
                             } else {
                                 $TABLE.rows.add([data.data[period]]);
                             }

--- a/shape/static/shape/js/mapApp.js
+++ b/shape/static/shape/js/mapApp.js
@@ -325,6 +325,7 @@ $(document).ready(function () {
                 pageLength: 30,
                 retrieve: true,
                 orderable: false,
+                order: [],
                 dom: 'Brt',
                 buttons: [
                     {
@@ -377,10 +378,8 @@ $(document).ready(function () {
                         $INFOMODAL.on('shown.bs.modal', function () {
                             let $TABLE = $('#shapeDetail').DataTable();
                             $TABLE.clear();
-                            console.log(period);
                             if (period === "0") {
-                                for (const [key, value] of Object.entries(data.data)) {
-                                    console.log(value);
+                                for (const value of Object.values(data.data)) {
                                     $TABLE.rows.add([value]);
                                 }
                             } else {

--- a/shape/static/shape/js/mapApp.js
+++ b/shape/static/shape/js/mapApp.js
@@ -374,7 +374,16 @@ $(document).ready(function () {
                         $INFOMODAL.modal("show");
                         $INFOMODAL.on('shown.bs.modal', function () {
                             let $TABLE = $('#shapeDetail').DataTable();
-                            $TABLE.clear().rows.add([data.data[period]]).draw();
+                            $TABLE.clear();
+                            if (period === 0) {
+                                data.data.forEach(function (e) {
+                                        $TABLE.rows.add(e)
+                                    }
+                                )
+                            } else {
+                                $TABLE.rows.add([data.data[period]]);
+                            }
+                            $TABLE.draw();
                             $(this).off('shown.bs.modal');
                         })
                     });


### PR DESCRIPTION
Cambios generales:
- Se modifica función get_op_route (obtener código de ruta en base al diccionario de servicios) añadiéndole el parámetro fecha del programa de operación a la búsqueda.
- Se corrigen todas las vistas que usen get_op_route asignandole la fecha correspondiente junto a sus tests.

Cambios en ficha de servicios:
- Se agrega selector para todos los periodos de Transantiago

Cambios en filterManager:
- Se corrige verificación de fechas válidas para programa de operación. El problema sucedía porque las fechas se comparaban como si fueran un arreglo de fechas [ fecha_1, ..., fecha_n ] pero viene en formato de arreglo de arreglos de fechas [ [ fecha_1, ...,  fecha_n ] , ..., [ fecha_m, ..., fecha_o ]]
