### PR TITLE
Uncouple op program dates and op dictionary

### DIFF
--- a/esapi/static/js/filterManager.js
+++ b/esapi/static/js/filterManager.js
@@ -139,10 +139,11 @@ function FilterManager(opts) {
             return 0;
         }
         let routesDict = operatorFilterData["routesDict"];
+        let opProgramDates = operatorFilterData["opProgramDates"];
         let firstDate = new Date(dates[0][0]);
         let lastIndex = dates.length - 1;
         let lastDate = new Date(dates[lastIndex][dates[lastIndex].length - 1]);
-        let routesDictKeys = Object.keys(routesDict).sort();
+        let routesDictKeys = Object.values(opProgramDates).sort();
         let periodDateValid = null;
         for (const date of routesDictKeys) {
             let validDate = new Date(date);
@@ -156,7 +157,8 @@ function FilterManager(opts) {
         }
         if (periodDateValid) {
             periodDateValid = periodDateValid.toISOString().slice(0, 10);
-            return routesDict[periodDateValid];
+            let response = routesDict[periodDateValid];
+            return response ? response : {};
         }
 
         return null;

--- a/esapi/tests/testODByRouteView.py
+++ b/esapi/tests/testODByRouteView.py
@@ -52,7 +52,8 @@ class AvailableRoutesTest(TestHelper):
                     '506': [self.available_route]
                 }
             },
-            'operatorDict': []
+            'operatorDict': [],
+            'opProgramDates': {}
         }
         self.assertJSONEqual(response.content, expected)
 

--- a/esapi/tests/testProfileView.py
+++ b/esapi/tests/testProfileView.py
@@ -145,7 +145,8 @@ class AvailableRoutesTest(TestHelper):
                 }
             },
             'operatorDict': [],
-            'routesDict': {}
+            'routesDict': {},
+            'opProgramDates': {}
         }
         self.assertJSONEqual(response.content, expected)
 

--- a/esapi/tests/testSpeedView.py
+++ b/esapi/tests/testSpeedView.py
@@ -53,7 +53,8 @@ class AvailableRoutesTest(TestHelper):
                 }
             },
             'operatorDict': [],
-            'routesDict': {}
+            'routesDict': {},
+            'opProgramDates': {}
         }
         self.assertJSONEqual(response.content, expected)
 

--- a/esapi/views/odbyroute.py
+++ b/esapi/views/odbyroute.py
@@ -13,7 +13,8 @@ from esapi.helper.odbyroute import ESODByRouteHelper
 from esapi.helper.stopbyroute import ESStopByRouteHelper
 from esapi.messages import ExporterDataHasBeenEnqueuedMessage
 from esapi.utils import check_operation_program, get_dates_from_request
-from localinfo.helper import PermissionBuilder, get_calendar_info, get_op_routes_dict
+from localinfo.helper import PermissionBuilder, get_calendar_info, get_op_routes_dict, \
+    get_opprogram_list_for_select_input
 
 
 class AvailableDays(View):
@@ -40,7 +41,9 @@ class AvailableRoutes(View):
         response = {
             'availableRoutes': available_days,
             'operatorDict': op_dict,
-            'routesDict': get_op_routes_dict()
+            'routesDict': get_op_routes_dict(),
+            'opProgramDates': get_opprogram_list_for_select_input(to_dict=True)
+
         }
 
         return JsonResponse(response)

--- a/esapi/views/profile.py
+++ b/esapi/views/profile.py
@@ -18,7 +18,7 @@ from esapi.messages import ExporterDataHasBeenEnqueuedMessage, ExpeditionsHaveBe
 from esapi.utils import check_operation_program
 from esapi.utils import get_dates_from_request
 from localinfo.helper import PermissionBuilder, get_day_type_list_for_select_input, get_timeperiod_list_for_select_input \
-    , get_calendar_info, get_op_routes_dict
+    , get_calendar_info, get_op_routes_dict, get_opprogram_list_for_select_input
 
 
 class LoadProfileByStopData(View):
@@ -138,6 +138,7 @@ class AvailableRoutes(View):
             response['availableRoutes'] = available_days
             response['operatorDict'] = op_dict
             response['routesDict'] = get_op_routes_dict()
+            response['opProgramDates'] = get_opprogram_list_for_select_input(to_dict=True)
         except FondefVizError as e:
             response['status'] = e.get_status_response()
 

--- a/esapi/views/speed.py
+++ b/esapi/views/speed.py
@@ -16,7 +16,8 @@ from esapi.helper.speed import ESSpeedHelper
 from esapi.messages import ExporterDataHasBeenEnqueuedMessage
 from esapi.messages import SpeedVariationWithLessDaysMessage
 from esapi.utils import check_operation_program, get_dates_from_request
-from localinfo.helper import PermissionBuilder, get_calendar_info, get_op_routes_dict
+from localinfo.helper import PermissionBuilder, get_calendar_info, get_op_routes_dict, \
+    get_opprogram_list_for_select_input
 
 hours = ["00:00", "00:30", "01:00", "01:30", "02:00", "02:30", "03:00", "03:30", "04:00", "04:30", "05:00",
          "05:30", "06:00", "06:30", "07:00", "07:30", "08:00", "08:30", "09:00", "09:30", "10:00", "10:30",
@@ -51,6 +52,8 @@ class AvailableRoutes(View):
             response['availableRoutes'] = available_days
             response['operatorDict'] = op_dict
             response['routesDict'] = get_op_routes_dict()
+            response['opProgramDates'] = get_opprogram_list_for_select_input(to_dict=True)
+
         except FondefVizError as e:
             response['status'] = e.get_status_response()
 


### PR DESCRIPTION
Se desacopla la obtención de programas de operación con los diccionarios de programa de operación:
### Backend 
 - Se modifican todas las clases AvailableRoutes agregándole el elemento opProgramDates a la respuesta, el cuál es un diccionario con las fechas que representan los programas de operación.
- Se corrigen los tests correspondientes.

### Frontend
- Se utiliza el elemento opProgramDates para validar las fechas seleccionadas (antes se utilizaba routesDict, el diccionario de programas de operaciones con rutas).
- Se adapta el resto del código para que se siga utilizando el elemento routesDict donde corresponda.