### PR TITLE
Dependencia de fechas a selector de Operador, Servicio de Usuario, Servicio TS

### DIFF
--- a/esapi/helper/odbyroute.py
+++ b/esapi/helper/odbyroute.py
@@ -22,7 +22,13 @@ class ESODByRouteHelper(ElasticSearchHelper):
     def get_available_days(self, valid_operator_list):
         return self._get_available_days('date', valid_operator_list)
 
-    def get_available_routes(self, valid_operator_list):
+    def get_available_routes(self, valid_operator_list, start_date=None, end_date=None):
+        """
+        :param start_date: intial date filter
+        :param end_date: last date filter
+        :param valid_operator_list: operators which user can ask
+        :return: dicts with available routes for user
+        """
         es_query = self.get_base_query()
         es_query = es_query[:0]
         es_query = es_query.source([])
@@ -31,6 +37,12 @@ class ESODByRouteHelper(ElasticSearchHelper):
             es_query = es_query.filter('terms', operator=valid_operator_list)
         else:
             raise ESQueryOperatorParameterDoesNotExist
+        if start_date and end_date:
+            es_query = es_query.filter('range', date={
+                'gte': '{0} 00:00:00'.format(start_date),
+                'lte': '{0} 23:59:59'.format(end_date),
+                'format': 'yyyy-MM-dd HH:mm:ss'
+            })
 
         aggs = A('terms', field="authRouteCode", size=5000)
         es_query.aggs.bucket('route', aggs)

--- a/esapi/helper/profile.py
+++ b/esapi/helper/profile.py
@@ -86,7 +86,6 @@ class ESProfileHelper(ElasticSearchHelper):
                 'lte': '{0} 23:59:59'.format(end_date),
                 'format': 'yyyy-MM-dd HH:mm:ss'
             })
-        print(es_query.to_dict())
         aggs = A('terms', field="route", size=5000)
         es_query.aggs.bucket('route', aggs)
 

--- a/esapi/helper/profile.py
+++ b/esapi/helper/profile.py
@@ -82,7 +82,7 @@ class ESProfileHelper(ElasticSearchHelper):
                 'format': 'yyyy-MM-dd HH:mm:ss'
             })
 
-            es_query = es_query.filter('range', expeditionEndTime={
+            es_query = es_query.filter('range', expeditionStartTime={
                 'lte': '{0} 23:59:59'.format(end_date),
                 'format': 'yyyy-MM-dd HH:mm:ss'
             })

--- a/esapi/helper/profile.py
+++ b/esapi/helper/profile.py
@@ -83,9 +83,10 @@ class ESProfileHelper(ElasticSearchHelper):
             })
 
             es_query = es_query.filter('range', expeditionEndTime={
-                'lte': '{0} 00:00:00'.format(end_date),
+                'lte': '{0} 23:59:59'.format(end_date),
                 'format': 'yyyy-MM-dd HH:mm:ss'
             })
+        print(es_query.to_dict())
         aggs = A('terms', field="route", size=5000)
         es_query.aggs.bucket('route', aggs)
 

--- a/esapi/helper/profile.py
+++ b/esapi/helper/profile.py
@@ -291,9 +291,19 @@ class ESProfileHelper(ElasticSearchHelper):
             metric('tripsCount', 'value_count', field='expandedAlighting')
         return es_query
 
-    def get_all_auth_routes(self):
+    def get_all_auth_routes(self, start_date=None, end_date=None):
         es_query = self.get_base_query()
         es_query = es_query[:0]
+        if start_date and end_date:
+            es_query = es_query.filter('range', expeditionStartTime={
+                'gte': '{0} 00:00:00'.format(start_date),
+                'format': 'yyyy-MM-dd HH:mm:ss'
+            })
+
+            es_query = es_query.filter('range', expeditionEndTime={
+                'lte': '{0} 23:59:59'.format(end_date),
+                'format': 'yyyy-MM-dd HH:mm:ss'
+            })
         aggs = A('terms', field="route", size=5000)
         es_query.aggs.bucket('route', aggs)
         return es_query

--- a/esapi/helper/speed.py
+++ b/esapi/helper/speed.py
@@ -22,9 +22,11 @@ class ESSpeedHelper(ElasticSearchHelper):
     def get_available_days(self, valid_operator_list):
         return self._get_available_days('date', valid_operator_list)
 
-    def get_available_routes(self, valid_operator_list):
+    def get_available_routes(self, valid_operator_list, start_date=None, end_date=None):
         """
         This is used in data filter panel
+        :param start_date: intial date filter
+        :param end_date: last date filter
         :param valid_operator_list: operators which user can ask
         :return: dicts with available routes for user
         """
@@ -36,6 +38,12 @@ class ESSpeedHelper(ElasticSearchHelper):
             es_query = es_query.filter('terms', operator=valid_operator_list)
         else:
             raise ESQueryOperatorParameterDoesNotExist()
+        if start_date and end_date:
+            es_query = es_query.filter('range', date={
+                'gte': '{0} 00:00:00'.format(start_date),
+                'lte': '{0} 23:59:59'.format(end_date),
+                'format': 'yyyy-MM-dd HH:mm:ss'
+            })
 
         aggs = A('terms', field="authRouteCode", size=5000)
         es_query.aggs.bucket('route', aggs)

--- a/esapi/static/js/filterManager.js
+++ b/esapi/static/js/filterManager.js
@@ -190,6 +190,7 @@ function FilterManager(opts) {
 
         } else if (validOpDict !== 0) {
             $OPERATOR_FILTER.select2({data: operatorFilterData["operatorDict"]});
+            console.log(operatorFilterData);
             let localOperatorFilter = window.localStorage.getItem(urlKey + "operatorFilter");
             if (localOperatorFilter) {
                 localOperatorFilter = JSON.parse(localOperatorFilter);
@@ -235,6 +236,32 @@ function FilterManager(opts) {
 
             }
         }
+    };
+
+    const updateOperatorFilterData = function () {
+        let dates = getDates();
+        let startDate = dates[0][0];
+        let lastIndex = dates.length - 1;
+        let endDate = dates[lastIndex][dates[lastIndex].length - 1];
+        let params = {
+            "start_date": startDate,
+            "end_date": endDate
+        };
+        $.getJSON(urlRouteData, params, function (data) {
+            if (data.status) {
+                showMessage(data.status);
+            } else {
+                data.operatorDict = data.operatorDict.map(function (el) {
+                    return {
+                        id: el.value,
+                        text: el.item
+                    }
+                });
+                operatorFilterData = data;
+            }
+        });
+        console.log(operatorFilterData);
+
     };
 
 
@@ -306,6 +333,7 @@ function FilterManager(opts) {
 
     $DAY_FILTER.change(function () {
         getTimePeriod();
+        //updateOperatorFilterData();
         if ($OPERATOR_FILTER.length && !$.isEmptyObject(operatorFilterData)) {
             getOperatorFilter();
         }
@@ -618,7 +646,11 @@ function FilterManager(opts) {
                 $AUTH_ROUTE_FILTER.empty();
                 $OPERATOR_FILTER.empty();
                 $USER_ROUTE_FILTER.empty();
+            }else if (userRouteId === null){
+                $AUTH_ROUTE_FILTER.empty();
+                $USER_ROUTE_FILTER.empty();
             } else {
+                console.log(operatorFilterData["availableRoutes"]);
                 let authRouteList = operatorFilterData["availableRoutes"][operatorId][userRouteId];
                 authRouteList.sort();
                 if (authRouteList.includes(localAuthRouteFilter.id)) {

--- a/esapi/static/js/filterManager.js
+++ b/esapi/static/js/filterManager.js
@@ -780,55 +780,6 @@ function FilterManager(opts) {
         $MULTI_AUTH_ROUTE_FILTER.change(function () {
             window.localStorage.setItem(urlKey + "multiAuthRouteFilter", JSON.stringify({id: $MULTI_AUTH_ROUTE_FILTER.val()}));
         });
-
-        /* const processMultiRouteData = function (data) {
-             let localMultiAuthRouteFilter = window.localStorage.getItem(urlKey + "multiAuthRouteFilter");
-             if (localMultiAuthRouteFilter) {
-                 localMultiAuthRouteFilter = JSON.parse(localMultiAuthRouteFilter);
-             }
-             let OpRoutesDict = getOPDictBetweenDates();
-             if (OpRoutesDict === null) {
-                 let status = {
-                     message: "Fechas seleccionadas pertenecen a más de un programa de operación",
-                     title: "Error",
-                     type: "error"
-                 };
-                 $MULTI_AUTH_ROUTE_FILTER.empty();
-                 showMessage(status);
-             } else if (OpRoutesDict === 0) {
-                 $MULTI_AUTH_ROUTE_FILTER.empty();
-             } else {
-                 data.data = data.data.map(function (el) {
-                     let dictName = ((OpRoutesDict[el.item]) === undefined) ? "" : ` (${OpRoutesDict[el.item].join(" | ")})`;
-                     return {id: el.item, text: `${el.item}${dictName}`};
-                 });
-             }
-
-
-             if ($MULTI_AUTH_ROUTE_FILTER.length) {
-                 $MULTI_AUTH_ROUTE_FILTER.select2({data: data.data});
-                 $MULTI_AUTH_ROUTE_FILTER.on("select2:select", function (e) {
-                     window.localStorage.setItem(urlKey + "multiAuthRouteFilter", JSON.stringify({id: $MULTI_AUTH_ROUTE_FILTER.val()}));
-                 });
-                 // call event to update user route filter
-                 var selectedItem = localMultiAuthRouteFilter !== null ? localMultiAuthRouteFilter : $MULTI_AUTH_ROUTE_FILTER.select2("data")[0];
-                 $MULTI_AUTH_ROUTE_FILTER.val(selectedItem).trigger("change").trigger({
-                     type: "select2:select",
-                     params: {data: selectedItem}
-                 });
-             }
-
-
-         };
-         */
-
-        $.getJSON(urlMultiRouteData, function (data) {
-            if (data.status) {
-                showMessage(data.status);
-            } else {
-                //operatorFilterData = data;
-            }
-        });
     }
 
 

--- a/esapi/views/odbyroute.py
+++ b/esapi/views/odbyroute.py
@@ -35,16 +35,24 @@ class AvailableDays(View):
 class AvailableRoutes(View):
 
     def get(self, request):
-        es_helper = ESODByRouteHelper()
-        valid_operator_id_list = PermissionBuilder().get_valid_operator_id_list(request.user)
-        available_days, op_dict = es_helper.get_available_routes(valid_operator_id_list)
-        response = {
-            'availableRoutes': available_days,
-            'operatorDict': op_dict,
-            'routesDict': get_op_routes_dict(),
-            'opProgramDates': get_opprogram_list_for_select_input(to_dict=True)
+        response = {}
+        start_date = request.GET.get("start_date", None)
+        end_date = request.GET.get("end_date", None)
+        try:
+            es_helper = ESODByRouteHelper()
+            valid_operator_id_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+            available_routes, op_dict = es_helper.get_available_routes(valid_operator_id_list, start_date, end_date)
+            available_operators = available_routes.keys()
+            op_dict = [operator_dict for operator_dict in op_dict if operator_dict["value"] in available_operators]
+            response = {
+                'availableRoutes': available_routes,
+                'operatorDict': op_dict,
+                'routesDict': get_op_routes_dict(),
+                'opProgramDates': get_opprogram_list_for_select_input(to_dict=True)
 
-        }
+            }
+        except FondefVizError as e:
+            response['status'] = e.get_status_response()
 
         return JsonResponse(response)
 

--- a/esapi/views/profile.py
+++ b/esapi/views/profile.py
@@ -136,8 +136,10 @@ class AvailableRoutes(View):
         try:
             es_helper = ESProfileHelper()
             valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
-            available_days, op_dict = es_helper.get_available_routes(valid_operator_list, start_date, end_date)
-            response['availableRoutes'] = available_days
+            available_routes, op_dict = es_helper.get_available_routes(valid_operator_list, start_date, end_date)
+            available_operators = available_routes.keys()
+            op_dict = [operator_dict for operator_dict in op_dict if operator_dict["value"] in available_operators]
+            response['availableRoutes'] = available_routes
             response['operatorDict'] = op_dict
             response['routesDict'] = get_op_routes_dict()
             response['opProgramDates'] = get_opprogram_list_for_select_input(to_dict=True)

--- a/esapi/views/profile.py
+++ b/esapi/views/profile.py
@@ -131,10 +131,12 @@ class AvailableRoutes(View):
     def get(self, request):
 
         response = {}
+        start_date = request.GET.get("start_date", None)
+        end_date = request.GET.get("end_date", None)
         try:
             es_helper = ESProfileHelper()
             valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
-            available_days, op_dict = es_helper.get_available_routes(valid_operator_list)
+            available_days, op_dict = es_helper.get_available_routes(valid_operator_list, start_date, end_date)
             response['availableRoutes'] = available_days
             response['operatorDict'] = op_dict
             response['routesDict'] = get_op_routes_dict()

--- a/esapi/views/speed.py
+++ b/esapi/views/speed.py
@@ -45,11 +45,15 @@ class AvailableRoutes(View):
 
     def get(self, request):
         response = {}
+        start_date = request.GET.get("start_date", None)
+        end_date = request.GET.get("end_date", None)
         try:
             es_helper = ESSpeedHelper()
             valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
-            available_days, op_dict = es_helper.get_available_routes(valid_operator_list)
-            response['availableRoutes'] = available_days
+            available_routes, op_dict = es_helper.get_available_routes(valid_operator_list, start_date, end_date)
+            available_operators = available_routes.keys()
+            op_dict = [operator_dict for operator_dict in op_dict if operator_dict["value"] in available_operators]
+            response['availableRoutes'] = available_routes
             response['operatorDict'] = op_dict
             response['routesDict'] = get_op_routes_dict()
             response['opProgramDates'] = get_opprogram_list_for_select_input(to_dict=True)

--- a/esapi/views/trip.py
+++ b/esapi/views/trip.py
@@ -15,7 +15,7 @@ from esapi.helper.stop import ESStopHelper
 from esapi.helper.trip import ESTripHelper
 from esapi.messages import ExporterDataHasBeenEnqueuedMessage
 from esapi.utils import get_dates_from_request
-from localinfo.helper import get_calendar_info, get_op_routes_dict
+from localinfo.helper import get_calendar_info, get_op_routes_dict, get_opprogram_list_for_select_input
 
 
 class ResumeData(PermissionRequiredMixin, View):
@@ -413,15 +413,21 @@ class MultiRouteData(View):
         if len(res) == 0:
             raise ESQueryResultEmpty()
         return {
-            'data': res
+            'availableRoutes': res
         }
 
     def process_request(self, request, params, export_data=False):
         es_helper = ESProfileHelper()
+        start_date = params.get("start_date", None)
+        end_date = params.get("end_date", None)
+        response = {}
         try:
-            es_query = es_helper.get_all_auth_routes()
+
+            es_query = es_helper.get_all_auth_routes(start_date, end_date)
             response = self.process_data(es_query)
             response['routesDict'] = get_op_routes_dict()
+            response['opProgramDates'] = get_opprogram_list_for_select_input(to_dict=True)
+
         except FondefVizError as e:
             response['status'] = e.get_status_response()
 


### PR DESCRIPTION
### Cambios en backend 
#### Profile
##### get_available_routes
- Se modifica filtro de fecha, cambiando la hora de 00:00:00 a 23:59:59 para el límite superior.
##### get_all_auth_routes
- Se le agrega el filtro de fecha
#### OdByRoute
- Se agrega filtro de fecha a vista y helper get_available_routes
#### Speed
- Se agrega filtro de fecha a vista y helper get_available_routes
#### Trip
- Se agrega filtro de fecha 

### Cambios en frontend
#### filterManager
- Se agrega el comportamiento para actualizar los operadores, rutas de usuario y rutas ts disponibles según la fecha seleccionada.
- Se eliminan las llamadas JSON a las urls que consultaban los operadores, rutas de usuario y rutas ts. Estas ahora se encuentra dentro de funciones para poder ser llamadas al momento de cambiar las fechas.
- Al cargar una vista o cambiar la fecha se sigue el siguiente algoritmo:
   - Si llama a la función que obtiene los operadores, rutas de usuario y rutas ts disponibles para las fechas seleccionadas.
   - Se actualiza la información recibida con el diccionario de programa de operación para las rutas ts que corresponda.
   - Se actualizan los valores seleccionados en caso de que sea posible, sino se selecciona el primer valor disponible para cada uno de los selectores.

