### PR TITLE
Hotfix/show data expedition view

### DIFF
--- a/esapi/static/js/filterManager.js
+++ b/esapi/static/js/filterManager.js
@@ -591,7 +591,7 @@ function FilterManager(opts) {
                         }
                     }
                     let status = false;
-                    if (!data.status || data.status.code === 252) {
+                    if (!data.status || data.status.code === 252 || data.status.code === 253) {
                         status = true;
                     }
                     if (afterCall) {

--- a/profile/static/profile/js/byExpedition.js
+++ b/profile/static/profile/js/byExpedition.js
@@ -674,7 +674,6 @@ $(document).ready(function () {
     }
 
     function processData(dataSource, app) {
-        console.log(dataSource);
 
         if (dataSource.status && (dataSource.status.code !== 252 && dataSource.status.code !== 253)) {
             return;


### PR DESCRIPTION
El problema surgió debido a que el refactoring consistía en definir cuando mostrar la información según el status para todas las vistas.

La gran mayoría de las vistas arrojan un status false cuando no se deben mostrar los datos excepto  una vista en particular que arroja el código 252, en esta se deben mostrar los datos.

La solución es añadir esta excepción (código 253) al filter manager tal como se hizo con la otra vista.