### PR TITLE
Feature/add evasion permission

### DIFF
--- a/dataDownloader/csvhelper/helper.py
+++ b/dataDownloader/csvhelper/helper.py
@@ -380,7 +380,7 @@ class ProfileCSVHelper(CSVHelper):
             {'es_name': 'evasionPercent', 'csv_name': '%evasión',
              'definition': 'Porcentaje de evasión aplicado a las transacciones de la parada-expedición.'},
             {'es_name': 'evasionType', 'csv_name': 'tipo_evasion',
-             'definition': 'puedes ser tres casos: 0, 1, 2, -1. El primero (0) indica que se usó una evasión a nivel de zonificación 777, el segundo valor (1) indica que se usó un valor de evasión a nivel de parada, y el tercer valor (2) indica que no se encontró un valor para el calculo de evasión. Existe un cuarto valor (-1) que indica que hubo un error con la información de evasión.'},
+             'definition': 'pueden ser tres casos: 0, 1, 2, -1. El primero (0) indica que se usó una evasión a nivel de zonificación 777, el segundo valor (1) indica que se usó un valor de evasión a nivel de parada, y el tercer valor (2) indica que no se encontró un valor para el calculo de evasión. Existe un cuarto valor (-1) que indica que hubo un error con la información de evasión.'},
             {'es_name': 'uniformDistributionMethod', 'csv_name': 'uniforme',
              'definition': 'método de distribución uniforme para casos donde no es posible estimar bajada, "0" indica que se usó una distribución uniforme y el valor "1" significa que no se usó distribución uniforme.'},
             {'es_name': 'passengerPerKmSection', 'csv_name': 'Pax-km_tramo',

--- a/dataDownloader/csvhelper/helper.py
+++ b/dataDownloader/csvhelper/helper.py
@@ -429,7 +429,6 @@ class ProfileCSVHelper(CSVHelper):
 class ProfileWithoutEvasionCSVHelper(ProfileCSVHelper):
     """ Class that represents a profile without evasion downloader. """
 
-
     def get_column_dict(self):
         return [
             {'es_name': 'operator', 'csv_name': 'Operador', 'definition': 'Empresa que opera el servicio'},

--- a/dataDownloader/csvhelper/helper.py
+++ b/dataDownloader/csvhelper/helper.py
@@ -486,10 +486,6 @@ class ProfileWithoutEvasionCSVHelper(ProfileCSVHelper):
              'definition': 'Número de personas que subieron y tienen bajada estimada por ADATRAP.'},
             {'es_name': 'uniformDistributionMethod', 'csv_name': 'uniforme',
              'definition': 'método de distribución uniforme para casos donde no es posible estimar bajada, "0" indica que se usó una distribución uniforme y el valor "1" significa que no se usó distribución uniforme.'},
-            {'es_name': 'passengerPerKmSection', 'csv_name': 'Pax-km_tramo',
-             'definition': 'Carga X distancia entre parada anterior y la del registro'},
-            {'es_name': 'capacityPerKmSection', 'csv_name': 'Plazas-km_tramo',
-             'definition': 'Plazas de bus X distancia entre parada anterior y la del registro'},
         ]
 
     def row_parser(self, row):

--- a/dataDownloader/csvhelper/helper.py
+++ b/dataDownloader/csvhelper/helper.py
@@ -24,6 +24,7 @@ from localinfo.helper import get_day_type_list_for_select_input, get_timeperiod_
 README_FILE_NAME = 'Léeme.txt'
 
 PROFILE_BY_EXPEDITION_DATA = 'profile_by_expedition'
+PROFILE_BY_EXPEDITION_WITHOUT_EVASION_DATA = 'profile_by_expedition_without_evasion'
 PROFILE_BY_STOP_DATA = 'profile_by_stop'
 OD_BY_ROUTE_DATA = 'od_by_route_data'
 SPEED_MATRIX_DATA = 'speed_matrix_data'
@@ -422,6 +423,98 @@ class ProfileCSVHelper(CSVHelper):
 
             formatted_row.append(value)
 
+        return formatted_row
+
+
+class ProfileWithoutEvasionCSVHelper(ProfileCSVHelper):
+    """ Class that represents a profile without evasion downloader. """
+
+
+    def get_column_dict(self):
+        return [
+            {'es_name': 'operator', 'csv_name': 'Operador', 'definition': 'Empresa que opera el servicio'},
+            {'es_name': 'route', 'csv_name': 'Servicio_transantiago',
+             'definition': 'Código de transantiago del servicio'},
+            {'es_name': 'userRoute', 'csv_name': 'Servicio_usuario',
+             'definition': 'Código de usuario del servicio (ejemplo: 506)'},
+            {'es_name': 'licensePlate', 'csv_name': 'Patente',
+             'definition': 'Patente de la máquina que realizó la expedición'},
+            {'es_name': 'authStopCode', 'csv_name': 'Código_parada_transantiago',
+             'definition': 'Código de transantiago de la parada por la que pasó el servicio'},
+            {'es_name': 'userStopCode', 'csv_name': 'Código_parada_usuario',
+             'definition': 'Código de usuario de la parada por la que pasó el servicio (ejemplo: PA433)'},
+            {'es_name': 'userStopName', 'csv_name': 'Nombre_parada',
+             'definition': 'Nombre de la parada por la que pasó el servicio'},
+            {'es_name': 'expeditionStartTime', 'csv_name': 'Hora_inicio_expedición',
+             'definition': 'Fecha y hora de inicio de la expedición'},
+            {'es_name': 'expeditionEndTime', 'csv_name': 'Hora_fin_expedición',
+             'definition': 'Fecha y hora de fin de la expedición'},
+            {'es_name': 'fulfillment', 'csv_name': 'Cumplimiento',
+             'definition': 'La expedición cumple la condición de cruzar por los puntos de control de inicio y fin de ruta indicado en el reporte 1.96'},
+            {'es_name': 'expeditionStopOrder', 'csv_name': 'Secuencia_parada',
+             'definition': 'Posición de la parada dentro de la secuencia de paradas asociada al servicio'},
+            {'es_name': 'expeditionDayId', 'csv_name': 'Identificador_expedición_día',
+             'definition': 'identificador de la expedición, es único dentro del día'},
+            {'es_name': 'stopDistanceFromPathStart', 'csv_name': 'Distancia_parada_desde_inicio_ruta',
+             'definition': 'Distancia en metros entre el inicio de la ruta del servicio y la parada, considera la geometría de la ruta (no es euclidiana)'},
+            {'es_name': 'expeditionStopTime', 'csv_name': 'Hora_en_parada',
+             'definition': 'Fecha y hora en que la máquina pasó por la parada'},
+            {'es_name': 'timePeriodInStartTime', 'csv_name': 'Periodo_transantiago_inicio_expedicion',
+             'definition': 'Período transantiago en que inició la expedición'},
+            {'es_name': 'timePeriodInStopTime', 'csv_name': 'Periodo_transantiago_parada_expedición',
+             'definition': 'Período transantiago en que el bus cruza la parada'},
+            {'es_name': 'dayType', 'csv_name': 'Tipo_dia',
+             'definition': 'Tipo de día considerado por adatrap al momento de realizar el procesamiento de los datos'},
+            {'es_name': 'busStation', 'csv_name': 'Zona_paga',
+             'definition': 'Indica si la parada es zona paga (1: es zona paga, 0: no es zona paga)'},
+            {'es_name': 'transactions', 'csv_name': 'Número_transacciones_en_parada',
+             'definition': 'Número de transacciones realizadas en el paradero'},
+            {'es_name': 'halfHourInStartTime', 'csv_name': 'Media_hora_de_inicio_expedición',
+             'definition': 'Indica el período de media hora que la expedición inicio el recorrido (ejemplo: 16:00:00)'},
+            {'es_name': 'halfHourInStopTime', 'csv_name': 'Media_hora_en_parada',
+             'definition': 'Indica el período de media hora que la expedición pasó por la parada (ejemplo: 16:00:00)'},
+            {'es_name': 'notValid', 'csv_name': 'Expedición_inválida',
+             'definition': 'Indica si la expedición contiene alguno de los siguientes problemas -> porcentaje de paraderos con carga menor a -1 es superior al 1% o porcentaje de paraderos con carga mayor al 1% sobre la capacidad del bus es superior al 1%'},
+            {'es_name': 'expandedBoarding', 'csv_name': 'Subidas_expandidas',
+             'definition': 'Número de personas que subieron al bus en la parada, la expansión se realiza por período-servicio-sentido'},
+            {'es_name': 'expandedAlighting', 'csv_name': 'Bajadas_expandidas',
+             'definition': 'Número de personas que bajaron del bus en la parada, la expansión se realiza por período-servicio-sentido'},
+            {'es_name': 'loadProfile', 'csv_name': 'Perfil_carga_al_llegar',
+             'definition': 'Número de personas arriba del bus al llegar a la parada'},
+            {'es_name': 'busCapacity', 'csv_name': 'Capacidad_bus',
+             'definition': 'Número máximo de personas que pueden estar dentro del bus'},
+            {'es_name': 'boardingWithAlighting', 'csv_name': 'Subidas_con_bajada',
+             'definition': 'Número de personas que subieron y tienen bajada estimada por ADATRAP.'},
+            {'es_name': 'uniformDistributionMethod', 'csv_name': 'uniforme',
+             'definition': 'método de distribución uniforme para casos donde no es posible estimar bajada, "0" indica que se usó una distribución uniforme y el valor "1" significa que no se usó distribución uniforme.'},
+            {'es_name': 'passengerPerKmSection', 'csv_name': 'Pax-km_tramo',
+             'definition': 'Carga X distancia entre parada anterior y la del registro'},
+            {'es_name': 'capacityPerKmSection', 'csv_name': 'Plazas-km_tramo',
+             'definition': 'Plazas de bus X distancia entre parada anterior y la del registro'},
+        ]
+
+    def row_parser(self, row):
+        formatted_row = []
+        for column_name in self.get_fields():
+            value = row[column_name]
+            try:
+                if column_name == 'dayType':
+                    value = self.day_type_dict[value]
+                elif column_name == 'operator':
+                    value = self.operator_dict[value]
+                elif column_name in ['timePeriodInStartTime', 'timePeriodInStopTime']:
+                    value = self.timeperiod_dict[value]
+                elif column_name in ['halfHourInStartTime', 'halfHourInStopTime']:
+                    value = self.halfhour_dict[value]
+            except KeyError:
+                value = ""
+
+            if isinstance(value, (int, float)):
+                value = str(value)
+            elif value is None:
+                value = ""
+            formatted_row.append(value)
+        print(formatted_row)
         return formatted_row
 
 

--- a/dataDownloader/csvhelper/helper.py
+++ b/dataDownloader/csvhelper/helper.py
@@ -514,7 +514,6 @@ class ProfileWithoutEvasionCSVHelper(ProfileCSVHelper):
             elif value is None:
                 value = ""
             formatted_row.append(value)
-        print(formatted_row)
         return formatted_row
 
 

--- a/dataDownloader/csvhelper/profile.py
+++ b/dataDownloader/csvhelper/profile.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 
-from dataDownloader.csvhelper.helper import ZipManager, ProfileCSVHelper, ShapeCSVHelper, StopByRouteCSVHelper
+from dataDownloader.csvhelper.helper import ZipManager, ProfileCSVHelper, ShapeCSVHelper, StopByRouteCSVHelper, \
+    ProfileWithoutEvasionCSVHelper
 
 
 class ProfileByExpeditionData(object):
@@ -75,6 +76,61 @@ class ProfileDataByStop(object):
 
         help_file_title = 'ARCHIVO DE PERFILES'
         files_description = [self.profile_file.get_file_description()]
+        data_filter = self.profile_file.get_filter_criteria(ProfileCSVHelper.FORMATTER_FOR_FILE)
+        explanation = self.profile_file.get_field_explanation()
+        zip_manager.build_readme(help_file_title, "".join(files_description), data_filter, explanation)
+
+
+class ProfileByExpeditionWithoutEvasionData:
+
+    def __init__(self, es_query, es_client=None):
+        self.es_query = es_query
+        self.es_client = settings.ES_CLIENT if es_client is None else es_client
+        self.profile_file = ProfileWithoutEvasionCSVHelper(self.es_client, self.es_query)
+
+    def get_routes(self):
+        for query_filter in self.es_query['query']['bool']['filter']:
+            if 'term' in query_filter and 'route' in query_filter['term']:
+                return [query_filter['term']['route']]
+            if 'terms' in query_filter and 'route' in query_filter['terms']:
+                return query_filter['terms']['route']
+
+    def get_date_range(self):
+        for query_filter in self.es_query['query']['bool']['filter']:
+            if 'bool' in query_filter:
+                should = query_filter['bool']['should']
+                field_a = list(should[0]['range'].keys())[0]
+                field_b = list(should[-1]['range'].keys())[0]
+
+                gte = should[0]['range'][field_a]["gte"].replace("||/d", "")
+                lte = should[-1]['range'][field_b]["lte"].replace("||/d", "")
+                return gte, lte
+            elif 'range' in query_filter:
+                field = list(query_filter['range'].keys())[0]
+                gte = query_filter['range'][field]["gte"].replace("||/d", "")
+                lte = query_filter['range'][field]["lte"].replace("||/d", "")
+                return gte, lte
+
+    def get_filters(self):
+        return self.profile_file.get_filter_criteria(ProfileCSVHelper.FORMATTER_FOR_WEB)
+
+    def build_file(self, file_path):
+        zip_manager = ZipManager(file_path)
+        self.profile_file.download(zip_manager)
+
+        routes = self.get_routes()
+
+        start_date, end_date = self.get_date_range()
+
+        shape_file = ShapeCSVHelper(self.es_client)
+        shape_file.download(zip_manager, routes=routes, start_date=start_date, end_date=end_date)
+
+        stop_file = StopByRouteCSVHelper(self.es_client)
+        stop_file.download(zip_manager, routes=routes, start_date=start_date, end_date=end_date)
+
+        help_file_title = 'ARCHIVO DE PERFILES'
+        files_description = [self.profile_file.get_file_description(), shape_file.get_file_description(),
+                             stop_file.get_file_description()]
         data_filter = self.profile_file.get_filter_criteria(ProfileCSVHelper.FORMATTER_FOR_FILE)
         explanation = self.profile_file.get_field_explanation()
         zip_manager.build_readme(help_file_title, "".join(files_description), data_filter, explanation)

--- a/dataDownloader/downloadData.py
+++ b/dataDownloader/downloadData.py
@@ -14,7 +14,8 @@ django.setup()
 
 from elasticsearch import Elasticsearch
 
-from dataDownloader.csvhelper.profile import ProfileByExpeditionData, ProfileDataByStop
+from dataDownloader.csvhelper.profile import ProfileByExpeditionData, ProfileDataByStop, \
+    ProfileByExpeditionWithoutEvasionData
 from dataDownloader.csvhelper.odbyroute import OdByRouteData
 from dataDownloader.csvhelper.speed import SpeedDataWithFormattedShape
 from dataDownloader.csvhelper.trip import TripData, PostProductTripTripBetweenZonesData, \
@@ -38,6 +39,8 @@ def download_file(es_instance, query, downloader, zip_file_path):
         data_to_download = ProfileByExpeditionData(query, es_instance)
     elif downloader == csv_helper.PROFILE_BY_STOP_DATA:
         data_to_download = ProfileDataByStop(query, es_instance)
+    elif downloader == csv_helper.PROFILE_BY_EXPEDITION_WITHOUT_EVASION_DATA:
+        data_to_download = ProfileByExpeditionWithoutEvasionData(query, es_instance)
     elif downloader == csv_helper.SPEED_MATRIX_DATA:
         data_to_download = SpeedDataWithFormattedShape(query, es_instance)
     elif downloader == csv_helper.TRIP_DATA:

--- a/dataDownloader/tests/testHelper.py
+++ b/dataDownloader/tests/testHelper.py
@@ -111,7 +111,7 @@ class TestProfileCSVHelper(TestCase):
                     {'es_name': 'evasionPercent', 'csv_name': '%evasión',
                      'definition': 'Porcentaje de evasión aplicado a las transacciones de la parada-expedición.'},
                     {'es_name': 'evasionType', 'csv_name': 'tipo_evasion',
-                     'definition': 'puedes ser tres casos: 0, 1, 2, -1. El primero (0) indica que se usó una evasión a nivel de zonificación 777, el segundo valor (1) indica que se usó un valor de evasión a nivel de parada, y el tercer valor (2) indica que no se encontró un valor para el calculo de evasión. Existe un cuarto valor (-1) que indica que hubo un error con la información de evasión.'},
+                     'definition': 'pueden ser tres casos: 0, 1, 2, -1. El primero (0) indica que se usó una evasión a nivel de zonificación 777, el segundo valor (1) indica que se usó un valor de evasión a nivel de parada, y el tercer valor (2) indica que no se encontró un valor para el calculo de evasión. Existe un cuarto valor (-1) que indica que hubo un error con la información de evasión.'},
                     {'es_name': 'uniformDistributionMethod', 'csv_name': 'uniforme',
                      'definition': 'método de distribución uniforme para casos donde no es posible estimar bajada, "0" indica que se usó una distribución uniforme y el valor "1" significa que no se usó distribución uniforme.'},
                     {'es_name': 'passengerPerKmSection', 'csv_name': 'Pax-km_tramo',

--- a/datamanager/helper.py
+++ b/datamanager/helper.py
@@ -12,7 +12,8 @@ import dataDownloader.csvhelper.helper as csv_helper
 from dataDownloader.csvhelper.bip import BipData
 from dataDownloader.csvhelper.odbyroute import OdByRouteData
 from dataDownloader.csvhelper.paymentfactor import PaymentFactorData
-from dataDownloader.csvhelper.profile import ProfileByExpeditionData, ProfileDataByStop
+from dataDownloader.csvhelper.profile import ProfileByExpeditionData, ProfileDataByStop, \
+    ProfileByExpeditionWithoutEvasionData
 from dataDownloader.csvhelper.speed import SpeedDataWithFormattedShape
 from dataDownloader.csvhelper.stage import PostProductStageTransferData, PostProductStageTransferAggregatedData
 from dataDownloader.csvhelper.trip import TripData, PostProductTripTripBetweenZonesData, \
@@ -101,6 +102,9 @@ class ExporterManager(object):
                 file_type = ExporterJobExecution.OD_BY_ROUTE
             elif downloader == csv_helper.PROFILE_BY_EXPEDITION_DATA:
                 downloader_instance = ProfileByExpeditionData(self.es_query.to_dict())
+                file_type = ExporterJobExecution.PROFILE
+            elif downloader == csv_helper.PROFILE_BY_EXPEDITION_WITHOUT_EVASION_DATA:
+                downloader_instance = ProfileByExpeditionWithoutEvasionData(self.es_query.to_dict())
                 file_type = ExporterJobExecution.PROFILE
             elif downloader == csv_helper.PROFILE_BY_STOP_DATA:
                 downloader_instance = ProfileDataByStop(self.es_query.to_dict())

--- a/esapi/helper/profile.py
+++ b/esapi/helper/profile.py
@@ -181,19 +181,7 @@ class ESProfileHelper(ElasticSearchHelper):
 
     def get_profile_by_expedition_data(self, dates, day_type, auth_route, period, half_hour,
                                        valid_operator_list, show_evasion=True):
-        """
-        Args:
-            dates:
-            day_type:
-            auth_route:
-            period:
-            half_hour:
-            valid_operator_list:
-            show_evasion:
 
-        Returns:
-
-        """
         es_query = self.get_base_profile_by_expedition_data_query(dates, day_type, auth_route, period,
                                                                   half_hour, valid_operator_list, show_evasion=show_evasion)[:0]
         stops = A('terms', field='authStopCode.raw', size=500)

--- a/esapi/helper/profile.py
+++ b/esapi/helper/profile.py
@@ -167,15 +167,14 @@ class ESProfileHelper(ElasticSearchHelper):
         # evasion data parameters
         evasion_data = ['expandedEvasionBoarding', 'expandedEvasionAlighting',
                         'expandedBoardingPlusExpandedEvasionBoarding', 'expandedAlightingPlusExpandedEvasionAlighting',
-                        'loadProfileWithEvasion', 'evasionPercent', 'evasionPercent',
-                        'passengerWithEvasionPerKmSection'] if show_evasion else []
+                        'loadProfileWithEvasion', 'evasionPercent', 'evasionType',
+                        'passengerWithEvasionPerKmSection', 'capacityPerKmSection'] if show_evasion else []
 
         es_query = es_query.source(
             ['busCapacity', 'licensePlate', 'route', 'loadProfile', 'expeditionDayId', 'expandedAlighting',
              'expandedBoarding', 'expeditionStartTime', 'expeditionEndTime', 'authStopCode', 'timePeriodInStartTime',
              'dayType', 'timePeriodInStopTime', 'busStation', 'path', 'notValid',
-             'boardingWithAlighting', 'boarding', 'uniformDistributionMethod',
-             'capacityPerKmSection'] + evasion_data)
+             'boardingWithAlighting', 'boarding', 'uniformDistributionMethod'] + evasion_data)
 
         return es_query
 
@@ -183,7 +182,8 @@ class ESProfileHelper(ElasticSearchHelper):
                                        valid_operator_list, show_evasion=True):
 
         es_query = self.get_base_profile_by_expedition_data_query(dates, day_type, auth_route, period,
-                                                                  half_hour, valid_operator_list, show_evasion=show_evasion)[:0]
+                                                                  half_hour, valid_operator_list,
+                                                                  show_evasion=show_evasion)[:0]
         stops = A('terms', field='authStopCode.raw', size=500)
 
         # evasion metrics
@@ -210,7 +210,7 @@ class ESProfileHelper(ElasticSearchHelper):
             metric('sumBusCapacity', 'sum', field='busCapacity'). \
             metric('busSaturation', 'bucket_script', script='params.d / params.t',
                    buckets_path={'d': 'sumLoadProfile', 't': 'sumBusCapacity'}). \
-            metric('pathDistance', 'top_hits', size=1, _source=['stopDistanceFromPathStart']).\
+            metric('pathDistance', 'top_hits', size=1, _source=['stopDistanceFromPathStart']). \
             metric('boardingWithAlighting', 'sum', field='boardingWithAlighting'). \
             metric('boarding', 'sum', field='boarding'). \
             metric('capacityPerKmSection', 'sum', field='capacityPerKmSection')

--- a/esapi/helper/profile.py
+++ b/esapi/helper/profile.py
@@ -199,7 +199,8 @@ class ESProfileHelper(ElasticSearchHelper):
                 metric('sumLoadProfileWithEvasion', 'sum', field='loadProfileWithEvasion'). \
                 metric('busSaturationWithEvasion', 'bucket_script', script='params.d / params.t',
                        buckets_path={'d': 'sumLoadProfileWithEvasion', 't': 'sumBusCapacity'}). \
-                metric('passengerWithEvasionPerKmSection', 'sum', field='passengerWithEvasionPerKmSection')
+                metric('passengerWithEvasionPerKmSection', 'sum', field='passengerWithEvasionPerKmSection'). \
+                metric('capacityPerKmSection', 'sum', field='capacityPerKmSection')
 
         stops_bucket = es_query.aggs.bucket('stops', stops)
         stops_bucket.metric('expandedAlighting', 'avg', field='expandedAlighting'). \
@@ -212,8 +213,7 @@ class ESProfileHelper(ElasticSearchHelper):
                    buckets_path={'d': 'sumLoadProfile', 't': 'sumBusCapacity'}). \
             metric('pathDistance', 'top_hits', size=1, _source=['stopDistanceFromPathStart']). \
             metric('boardingWithAlighting', 'sum', field='boardingWithAlighting'). \
-            metric('boarding', 'sum', field='boarding'). \
-            metric('capacityPerKmSection', 'sum', field='capacityPerKmSection')
+            metric('boarding', 'sum', field='boarding')
 
         if show_evasion:
             apply_evasion_metrics(stops_bucket)

--- a/esapi/tests/testProfileIndex.py
+++ b/esapi/tests/testProfileIndex.py
@@ -151,7 +151,6 @@ class ESProfileIndexTest(TestCase):
                                 'evasionPercent', 'evasionPercent', 'passengerWithEvasionPerKmSection']}
 
         self.assertIsInstance(result, Search)
-        print(result.to_dict())
         self.assertDictEqual(result.to_dict(), expected)
 
     def test_get_profile_by_expedition_data(self):

--- a/esapi/tests/testProfileIndex.py
+++ b/esapi/tests/testProfileIndex.py
@@ -134,32 +134,30 @@ class ESProfileIndexTest(TestCase):
         dates = [['2018-01-01', '2018-01-02']]
         result = self.instance.get_base_profile_by_expedition_data_query(dates, day_type, auth_route,
                                                                          period, half_hour,
-                                                                         valid_operator_list)
+                                                                         valid_operator_list, show_evasion=True)
         expected = {'query': {'bool': {'filter': [{'term': {'fulfillment': 'C'}}, {'terms': {'operator': [1, 2, 3]}},
-                                                  {'term': {'route': '506 00I'}},
-                                                  {'terms': {'dayType': ['LABORAL']}},
+                                                  {'term': {'route': '506 00I'}}, {'terms': {'dayType': ['LABORAL']}},
                                                   {'terms': {'timePeriodInStartTime': [1, 2, 3]}},
                                                   {'terms': {'halfHourInStartTime': [1, 2, 3]}}, {'range': {
-                'expeditionStartTime': {'time_zone': '+00:00', 'gte': '2018-01-01||/d', 'lte': '2018-01-02||/d',
-                                        'format': 'yyyy-MM-dd'}}}, {'term': {'notValid': 0}}]}},
+                'expeditionStartTime': {'gte': '2018-01-01||/d', 'lte': '2018-01-02||/d', 'format': 'yyyy-MM-dd',
+                                        'time_zone': '+00:00'}}}, {'term': {'notValid': 0}}]}},
                     '_source': ['busCapacity', 'licensePlate', 'route', 'loadProfile', 'expeditionDayId',
                                 'expandedAlighting', 'expandedBoarding', 'expeditionStartTime', 'expeditionEndTime',
                                 'authStopCode', 'timePeriodInStartTime', 'dayType', 'timePeriodInStopTime',
-                                'busStation', 'path', 'notValid', 'expandedEvasionBoarding',
-                                'expandedEvasionAlighting',
-                                'expandedBoardingPlusExpandedEvasionBoarding',
+                                'busStation', 'path', 'notValid', 'boardingWithAlighting', 'boarding',
+                                'uniformDistributionMethod', 'capacityPerKmSection', 'expandedEvasionBoarding',
+                                'expandedEvasionAlighting', 'expandedBoardingPlusExpandedEvasionBoarding',
                                 'expandedAlightingPlusExpandedEvasionAlighting', 'loadProfileWithEvasion',
-                                'boardingWithAlighting', 'boarding', 'evasionPercent', 'evasionPercent',
-                                'uniformDistributionMethod', 'passengerWithEvasionPerKmSection',
-                                'capacityPerKmSection']}
+                                'evasionPercent', 'evasionPercent', 'passengerWithEvasionPerKmSection']}
 
         self.assertIsInstance(result, Search)
+        print(result.to_dict())
         self.assertDictEqual(result.to_dict(), expected)
 
     def test_get_profile_by_expedition_data(self):
         dates = [['2018-01-01', '2018-02-01']]
         result = self.instance.get_profile_by_expedition_data(dates, ['LABORAL'], 'route', [1, 2, 3],
-                                                              [1, 2, 3], [1, 2, 3])
+                                                              [1, 2, 3], [1, 2, 3], show_evasion=True)
         expected = {'query': {'bool': {
             'filter': [{'term': {'fulfillment': 'C'}}, {'terms': {'operator': [1, 2, 3]}}, {'term': {'route': 'route'}},
                        {'terms': {'dayType': ['LABORAL']}}, {'terms': {'timePeriodInStartTime': [1, 2, 3]}},
@@ -176,6 +174,9 @@ class ESProfileIndexTest(TestCase):
                               'bucket_script': {'script': 'params.d / params.t',
                                                 'buckets_path': {'d': 'sumLoadProfile', 't': 'sumBusCapacity'}}},
                                'pathDistance': {'top_hits': {'size': 1, '_source': ['stopDistanceFromPathStart']}},
+                               'boardingWithAlighting': {'sum': {'field': 'boardingWithAlighting'}},
+                               'boarding': {'sum': {'field': 'boarding'}},
+                               'capacityPerKmSection': {'sum': {'field': 'capacityPerKmSection'}},
                                'expandedEvasionBoarding': {'avg': {'field': 'expandedEvasionBoarding'}},
                                'expandedEvasionAlighting': {'avg': {'field': 'expandedEvasionAlighting'}},
                                'expandedBoardingPlusExpandedEvasionBoarding': {
@@ -185,25 +186,22 @@ class ESProfileIndexTest(TestCase):
                                'loadProfileWithEvasion': {'avg': {'field': 'loadProfileWithEvasion'}},
                                'maxLoadProfileWithEvasion': {'max': {'field': 'loadProfileWithEvasion'}},
                                'sumLoadProfileWithEvasion': {'sum': {'field': 'loadProfileWithEvasion'}},
-                               'busSaturationWithEvasion': {
-                                   'bucket_script': {'script': 'params.d / params.t',
-                                                     'buckets_path': {'d': 'sumLoadProfileWithEvasion',
-                                                                      't': 'sumBusCapacity'}}},
-                               'boardingWithAlighting': {'sum': {'field': 'boardingWithAlighting'}},
-                               'boarding': {'sum': {'field': 'boarding'}},
+                               'busSaturationWithEvasion': {'bucket_script': {'script': 'params.d / params.t',
+                                                                              'buckets_path': {
+                                                                                  'd': 'sumLoadProfileWithEvasion',
+                                                                                  't': 'sumBusCapacity'}}},
                                'passengerWithEvasionPerKmSection': {
-                                   'sum': {'field': 'passengerWithEvasionPerKmSection'}},
-                               'capacityPerKmSection': {'sum': {'field': 'capacityPerKmSection'}}}},
+                                   'sum': {'field': 'passengerWithEvasionPerKmSection'}}}},
             'stop': {'filter': {'term': {'busStation': 1}},
                      'aggs': {'station': {'terms': {'field': 'authStopCode.raw', 'size': 500}}}}}, 'from': 0, 'size': 0,
-            '_source': ['busCapacity', 'licensePlate', 'route', 'loadProfile', 'expeditionDayId',
-                        'expandedAlighting', 'expandedBoarding', 'expeditionStartTime', 'expeditionEndTime',
-                        'authStopCode', 'timePeriodInStartTime', 'dayType', 'timePeriodInStopTime',
-                        'busStation', 'path', 'notValid', 'expandedEvasionBoarding', 'expandedEvasionAlighting',
-                        'expandedBoardingPlusExpandedEvasionBoarding',
-                        'expandedAlightingPlusExpandedEvasionAlighting', 'loadProfileWithEvasion',
-                        'boardingWithAlighting', 'boarding', 'evasionPercent', 'evasionPercent',
-                        'uniformDistributionMethod', 'passengerWithEvasionPerKmSection', 'capacityPerKmSection']}
+                    '_source': ['busCapacity', 'licensePlate', 'route', 'loadProfile', 'expeditionDayId',
+                                'expandedAlighting', 'expandedBoarding', 'expeditionStartTime', 'expeditionEndTime',
+                                'authStopCode', 'timePeriodInStartTime', 'dayType', 'timePeriodInStopTime',
+                                'busStation', 'path', 'notValid', 'boardingWithAlighting', 'boarding',
+                                'uniformDistributionMethod', 'capacityPerKmSection', 'expandedEvasionBoarding',
+                                'expandedEvasionAlighting', 'expandedBoardingPlusExpandedEvasionBoarding',
+                                'expandedAlightingPlusExpandedEvasionAlighting', 'loadProfileWithEvasion',
+                                'evasionPercent', 'evasionPercent', 'passengerWithEvasionPerKmSection']}
 
         self.assertIsInstance(result, Search)
         self.assertDictEqual(result.to_dict(), expected)

--- a/esapi/tests/testProfileIndex.py
+++ b/esapi/tests/testProfileIndex.py
@@ -145,10 +145,11 @@ class ESProfileIndexTest(TestCase):
                                 'expandedAlighting', 'expandedBoarding', 'expeditionStartTime', 'expeditionEndTime',
                                 'authStopCode', 'timePeriodInStartTime', 'dayType', 'timePeriodInStopTime',
                                 'busStation', 'path', 'notValid', 'boardingWithAlighting', 'boarding',
-                                'uniformDistributionMethod', 'capacityPerKmSection', 'expandedEvasionBoarding',
-                                'expandedEvasionAlighting', 'expandedBoardingPlusExpandedEvasionBoarding',
+                                'uniformDistributionMethod', 'expandedEvasionBoarding', 'expandedEvasionAlighting',
+                                'expandedBoardingPlusExpandedEvasionBoarding',
                                 'expandedAlightingPlusExpandedEvasionAlighting', 'loadProfileWithEvasion',
-                                'evasionPercent', 'evasionPercent', 'passengerWithEvasionPerKmSection']}
+                                'evasionPercent', 'evasionType', 'passengerWithEvasionPerKmSection',
+                                'capacityPerKmSection']}
 
         self.assertIsInstance(result, Search)
         self.assertDictEqual(result.to_dict(), expected)
@@ -175,7 +176,6 @@ class ESProfileIndexTest(TestCase):
                                'pathDistance': {'top_hits': {'size': 1, '_source': ['stopDistanceFromPathStart']}},
                                'boardingWithAlighting': {'sum': {'field': 'boardingWithAlighting'}},
                                'boarding': {'sum': {'field': 'boarding'}},
-                               'capacityPerKmSection': {'sum': {'field': 'capacityPerKmSection'}},
                                'expandedEvasionBoarding': {'avg': {'field': 'expandedEvasionBoarding'}},
                                'expandedEvasionAlighting': {'avg': {'field': 'expandedEvasionAlighting'}},
                                'expandedBoardingPlusExpandedEvasionBoarding': {
@@ -190,17 +190,18 @@ class ESProfileIndexTest(TestCase):
                                                                                   'd': 'sumLoadProfileWithEvasion',
                                                                                   't': 'sumBusCapacity'}}},
                                'passengerWithEvasionPerKmSection': {
-                                   'sum': {'field': 'passengerWithEvasionPerKmSection'}}}},
+                                   'sum': {'field': 'passengerWithEvasionPerKmSection'}},
+                               'capacityPerKmSection': {'sum': {'field': 'capacityPerKmSection'}}}},
             'stop': {'filter': {'term': {'busStation': 1}},
                      'aggs': {'station': {'terms': {'field': 'authStopCode.raw', 'size': 500}}}}}, 'from': 0, 'size': 0,
-                    '_source': ['busCapacity', 'licensePlate', 'route', 'loadProfile', 'expeditionDayId',
-                                'expandedAlighting', 'expandedBoarding', 'expeditionStartTime', 'expeditionEndTime',
-                                'authStopCode', 'timePeriodInStartTime', 'dayType', 'timePeriodInStopTime',
-                                'busStation', 'path', 'notValid', 'boardingWithAlighting', 'boarding',
-                                'uniformDistributionMethod', 'capacityPerKmSection', 'expandedEvasionBoarding',
-                                'expandedEvasionAlighting', 'expandedBoardingPlusExpandedEvasionBoarding',
-                                'expandedAlightingPlusExpandedEvasionAlighting', 'loadProfileWithEvasion',
-                                'evasionPercent', 'evasionPercent', 'passengerWithEvasionPerKmSection']}
+            '_source': ['busCapacity', 'licensePlate', 'route', 'loadProfile', 'expeditionDayId',
+                        'expandedAlighting', 'expandedBoarding', 'expeditionStartTime', 'expeditionEndTime',
+                        'authStopCode', 'timePeriodInStartTime', 'dayType', 'timePeriodInStopTime',
+                        'busStation', 'path', 'notValid', 'boardingWithAlighting', 'boarding',
+                        'uniformDistributionMethod', 'expandedEvasionBoarding',
+                        'expandedEvasionAlighting', 'expandedBoardingPlusExpandedEvasionBoarding',
+                        'expandedAlightingPlusExpandedEvasionAlighting', 'loadProfileWithEvasion',
+                        'evasionPercent', 'evasionType', 'passengerWithEvasionPerKmSection', 'capacityPerKmSection']}
 
         self.assertIsInstance(result, Search)
         self.assertDictEqual(result.to_dict(), expected)

--- a/esapi/views/bip.py
+++ b/esapi/views/bip.py
@@ -50,7 +50,7 @@ class BipTransactionByOperatorData(View):
     def process_request(self, request, params, export_data=False):
         response = {}
         dates = get_dates_from_request(request, export_data)
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
         try:
             if not dates or not isinstance(dates[0], list) or not dates[0]:
                 raise ESQueryDateParametersDoesNotExist

--- a/esapi/views/odbyroute.py
+++ b/esapi/views/odbyroute.py
@@ -18,7 +18,7 @@ class AvailableDays(View):
 
     def get(self, request):
         es_helper = ESODByRouteHelper()
-        valid_operator_id_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_id_list = PermissionBuilder.get_valid_operator_id_list(request.user)
         available_days = es_helper.get_available_days(valid_operator_id_list)
         calendar_info = get_calendar_info()
         response = {
@@ -37,7 +37,7 @@ class AvailableRoutes(View):
         end_date = request.GET.get("end_date", None)
         try:
             es_helper = ESODByRouteHelper()
-            valid_operator_id_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+            valid_operator_id_list = PermissionBuilder.get_valid_operator_id_list(request.user)
             available_routes, op_dict = es_helper.get_available_routes(valid_operator_id_list, start_date, end_date)
             available_operators = available_routes.keys()
             op_dict = [operator_dict for operator_dict in op_dict if operator_dict["value"] in available_operators]
@@ -72,7 +72,7 @@ class ODMatrixData(View):
             'data': {}
         }
 
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
 
         try:
             if not dates or not isinstance(dates[0], list) or not dates[0]:

--- a/esapi/views/profile.py
+++ b/esapi/views/profile.py
@@ -230,8 +230,12 @@ class LoadProfileByExpeditionData(View):
             if export_data:
                 es_query = es_profile_helper.get_base_profile_by_expedition_data_query(dates, day_type,
                                                                                        auth_route_code, period,
-                                                                                       half_hour, valid_operator_list)
-                ExporterManager(es_query).export_data(csv_helper.PROFILE_BY_EXPEDITION_DATA, request.user)
+                                                                                       half_hour, valid_operator_list,
+                                                                                       show_evasion)
+                if show_evasion:
+                    ExporterManager(es_query).export_data(csv_helper.PROFILE_BY_EXPEDITION_DATA, request.user)
+                else:
+                    ExporterManager(es_query).export_data(csv_helper.PROFILE_BY_EXPEDITION_WITHOUT_EVASION_DATA, request.user)
                 response['status'] = ExporterDataHasBeenEnqueuedMessage().get_status_response()
             else:
                 diff_days = 0

--- a/esapi/views/profile.py
+++ b/esapi/views/profile.py
@@ -262,7 +262,7 @@ class LoadProfileByExpeditionData(View):
                     response['status'] = ExpeditionsHaveBeenGroupedMessage(day_limit).get_status_response()
                 response['stops'] = es_stop_helper.get_stop_list(auth_route_code, dates)['stops']
                 response['shape'] = es_shape_helper.get_route_shape(auth_route_code, dates)['points']
-                response['show_evasion'] = show_evasion
+                response['showEvasion'] = show_evasion
         except FondefVizError as e:
             response['status'] = e.get_status_response()
         return JsonResponse(response, safe=False)

--- a/esapi/views/profile.py
+++ b/esapi/views/profile.py
@@ -83,7 +83,7 @@ class LoadProfileByStopData(View):
         period = params.getlist('period[]', [])
         half_hour = params.getlist('halfHour[]', [])
 
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
 
         try:
             if not dates or not isinstance(dates[0], list) or not dates[0]:
@@ -114,7 +114,7 @@ class AvailableDays(View):
 
     def get(self, request):
         es_helper = ESProfileHelper()
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
         available_days = es_helper.get_available_days(valid_operator_list)
         calendar_info = get_calendar_info()
         response = {
@@ -134,7 +134,7 @@ class AvailableRoutes(View):
         end_date = request.GET.get("end_date", None)
         try:
             es_helper = ESProfileHelper()
-            valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+            valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
             available_routes, op_dict = es_helper.get_available_routes(valid_operator_list, start_date, end_date)
             available_operators = available_routes.keys()
             op_dict = [operator_dict for operator_dict in op_dict if operator_dict["value"] in available_operators]
@@ -216,7 +216,7 @@ class LoadProfileByExpeditionData(View):
         period = params.getlist('period[]')
         half_hour = params.getlist('halfHour[]')
 
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
         show_evasion = PermissionBuilder.has_evasion_permission(request.user)
         response = {}
         try:
@@ -339,7 +339,7 @@ class LoadProfileByTrajectoryData(View):
         period = params.getlist('period[]')
         half_hour = params.getlist('halfHour[]')
 
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
 
         response = {}
 
@@ -401,7 +401,7 @@ class BoardingAndAlightingAverageByStops(View):
         stop_codes = params.getlist('stopCodes[]', [])
         period = params.getlist('period[]', [])
         half_hour = params.getlist('halfHour[]', [])
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
 
         try:
             if not dates or not isinstance(dates[0], list) or not dates[0]:

--- a/esapi/views/profile.py
+++ b/esapi/views/profile.py
@@ -235,7 +235,8 @@ class LoadProfileByExpeditionData(View):
                 if show_evasion:
                     ExporterManager(es_query).export_data(csv_helper.PROFILE_BY_EXPEDITION_DATA, request.user)
                 else:
-                    ExporterManager(es_query).export_data(csv_helper.PROFILE_BY_EXPEDITION_WITHOUT_EVASION_DATA, request.user)
+                    ExporterManager(es_query).export_data(csv_helper.PROFILE_BY_EXPEDITION_WITHOUT_EVASION_DATA,
+                                                          request.user)
                 response['status'] = ExporterDataHasBeenEnqueuedMessage().get_status_response()
             else:
                 diff_days = 0
@@ -353,7 +354,8 @@ class LoadProfileByTrajectoryData(View):
                                                                                    auth_route_code, period, half_hour,
                                                                                    valid_operator_list)
             if export_data:
-                ExporterManager(es_query).export_data(csv_helper.PROFILE_BY_EXPEDITION_DATA, request.user)
+                ExporterManager(es_query).export_data(csv_helper.PROFILE_BY_EXPEDITION_WITHOUT_EVASION_DATA,
+                                                      request.user)
                 response['status'] = ExporterDataHasBeenEnqueuedMessage().get_status_response()
             else:
                 response['trips'], response['busStations'], exp_not_valid_number = self.transform_answer(es_query)

--- a/esapi/views/shape.py
+++ b/esapi/views/shape.py
@@ -83,7 +83,7 @@ class GetUserRoutesByOP(View):
             end_date = date.fromisoformat(end_date) - timedelta(days=1)
             end_date = end_date.isoformat()
 
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
         es_helper = ESProfileHelper()
 
         available_routes, op_dict = es_helper.get_available_routes(valid_operator_list, start_date=start_date,

--- a/esapi/views/speed.py
+++ b/esapi/views/speed.py
@@ -27,7 +27,7 @@ class AvailableDays(View):
 
     def get(self, request):
         es_helper = ESSpeedHelper()
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
         available_days = es_helper.get_available_days(valid_operator_list)
         calendar_info = get_calendar_info()
         response = {
@@ -46,7 +46,7 @@ class AvailableRoutes(View):
         end_date = request.GET.get("end_date", None)
         try:
             es_helper = ESSpeedHelper()
-            valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+            valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
             available_routes, op_dict = es_helper.get_available_routes(valid_operator_list, start_date, end_date)
             available_operators = available_routes.keys()
             op_dict = [operator_dict for operator_dict in op_dict if operator_dict["value"] in available_operators]
@@ -73,7 +73,7 @@ class MatrixData(View):
         auth_route = params.get('authRoute', '')
         day_type = params.getlist('dayType[]', [])
 
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
 
         response = {
             'segments': [],
@@ -139,7 +139,7 @@ class RankingData(View):
         hour_period_from = params.get('hourPeriodFrom', None)
         hour_period_to = params.get('hourPeriodTo', None)
         day_type = params.getlist('dayType[]', None)
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
 
         response = {
             'hours': hours,
@@ -207,7 +207,7 @@ class SpeedByRoute(View):
         hour_period = params.get('period', [])
         day_type = params.getlist('dayType[]', [])
 
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
 
         response = {
             'route': {
@@ -338,7 +338,7 @@ class SpeedVariation(View):
         user_route = params.get('userRoute', '')
         day_type = params.getlist('dayType[]', '')
 
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
 
         response = {
             'variations': [],

--- a/esapi/views/stage.py
+++ b/esapi/views/stage.py
@@ -16,7 +16,7 @@ class AvailableDays(View):
 
     def get(self, request):
         es_helper = ESStageHelper()
-        valid_operator_list = PermissionBuilder().get_valid_operator_id_list(request.user)
+        valid_operator_list = PermissionBuilder.get_valid_operator_id_list(request.user)
         available_days = es_helper.get_available_days(valid_operator_list)
         calendar_info = get_calendar_info()
         response = {

--- a/localinfo/helper.py
+++ b/localinfo/helper.py
@@ -400,3 +400,8 @@ class PermissionBuilder(object):
                 answer.append(esId)
 
         return answer
+
+    @staticmethod
+    def has_evasion_permission(user) -> bool:
+        """Check if an user has evasion permission"""
+        return user.groups.filter(name='Ver datos de evasión en perfil de carga').exists()

--- a/localinfo/helper.py
+++ b/localinfo/helper.py
@@ -343,6 +343,12 @@ class PermissionBuilder(object):
         storage_group.permissions.add(storage_permission)
 
         # create permission to see postproduct section
+        evasion_permission, _ = GlobalPermission.objects.get_or_create(
+            codename='evasion', defaults={'name': 'Evasión en perfil de carga'})
+        evasion_group, _ = Group.objects.get_or_create(name='Ver datos de evasión en perfil de carga')
+        evasion_group.permissions.add(evasion_permission)
+
+        # create permission to see evasion data
         post_products_permission, _ = GlobalPermission.objects.get_or_create(
             codename='postproducts', defaults={'name': 'productos post'})
         post_products_group, _ = Group.objects.get_or_create(name='Sección de productos post')

--- a/localinfo/helper.py
+++ b/localinfo/helper.py
@@ -396,7 +396,8 @@ class PermissionBuilder(object):
 
         permission.delete()
 
-    def get_valid_operator_id_list(self, user):
+    @staticmethod
+    def get_valid_operator_id_list(user) -> list:
         """
         return list of operator esId field valid for user
         """

--- a/localinfo/helper.py
+++ b/localinfo/helper.py
@@ -342,13 +342,13 @@ class PermissionBuilder(object):
         storage_group, _ = Group.objects.get_or_create(name='Sección de validaciones')
         storage_group.permissions.add(storage_permission)
 
-        # create permission to see postproduct section
+        # create permission to see evasion data
         evasion_permission, _ = GlobalPermission.objects.get_or_create(
             codename='evasion', defaults={'name': 'Evasión en perfil de carga'})
         evasion_group, _ = Group.objects.get_or_create(name='Ver datos de evasión en perfil de carga')
         evasion_group.permissions.add(evasion_permission)
 
-        # create permission to see evasion data
+        # create permission to see postproduct section
         post_products_permission, _ = GlobalPermission.objects.get_or_create(
             codename='postproducts', defaults={'name': 'productos post'})
         post_products_group, _ = Group.objects.get_or_create(name='Sección de productos post')

--- a/localinfo/tests/testHelper.py
+++ b/localinfo/tests/testHelper.py
@@ -12,7 +12,7 @@ from localinfo.helper import get_op_route, get_op_routes_dict, _list_parser, _di
     get_halfhour_list_for_select_input, get_commune_list_for_select_input, get_transport_mode_list_for_select_input, \
     get_calendar_info, get_all_faqs, search_faq, get_valid_time_period_date, get_periods_dict, synchronize_op_program, \
     get_opprogram_list_for_select_input, upload_csv_op_dictionary, check_period_list_id, \
-    create_csv_format_users_list
+    create_csv_format_users_list, PermissionBuilder
 from localinfo.models import DayDescription, CalendarInfo, OPDictionary, FAQ, OPProgram
 
 
@@ -678,3 +678,11 @@ class TestHelperUtils(TestCase):
             header,
             ['test_user', 'test@user.com', 'test', 'user', 'No', formatted_login_time, "Si", "No"]]
         self.assertEqual(expected_user_list, create_csv_format_users_list())
+
+    def test_has_evasion_permission(self):
+        login_time = timezone.now()
+        user = User.objects.create(password="test_user_password", first_name="test", last_name="user",
+                                   username="test_user", email="test@user.com", last_login=login_time)
+        group = Group.objects.create(name="Ver datos de evasión en perfil de carga")
+        group.user_set.add(user)
+        self.assertTrue(PermissionBuilder.has_evasion_permission(user))

--- a/profile/static/profile/js/byExpedition.js
+++ b/profile/static/profile/js/byExpedition.js
@@ -967,14 +967,16 @@ $(document).ready(function () {
      */
     this.manageEvasionDisplay = function (showEvasion) {
       if (showEvasion) {
-        let options = {legend: {
+        let options = {
+          legend: {
             data: [
               "Subidas", "Subidas evadidas",
               "Bajadas", "Bajadas evadidas",
               "Carga prom.", "Carga prom. con evasión",
               "Carga máx.", "Carga máx. con evasión",
               "% ocupación", "% ocupación con evasión"]
-          }};
+          }
+        };
         _barChart.setOption(options, {
           replaceMerge: 'legend'
         });
@@ -1028,16 +1030,19 @@ $(document).ready(function () {
           distOnPath: el.pathDistance.hits.hits[0]._source.stopDistanceFromPathStart,
           expeditionNumber: el.doc_count,
           maxLoadProfile: el.maxLoadProfile.value,
-          loadProfileWithEvasion: el.loadProfileWithEvasion.value,
-          maxLoadProfileWithEvasion: el.maxLoadProfileWithEvasion.value,
-          expandedEvasionBoarding: el.expandedEvasionBoarding.value,
-          expandedEvasionAlighting: el.expandedEvasionAlighting.value,
-          expandedBoardingPlusExpandedEvasionBoarding: el.expandedBoardingPlusExpandedEvasionBoarding.value,
-          expandedAlightingPlusExpandedEvasionAlighting: el.expandedAlightingPlusExpandedEvasionAlighting.value,
-          busSaturationWithEvasion: el.busSaturationWithEvasion.value,
+          loadProfileWithEvasion: el.loadProfileWithEvasion ? el.loadProfileWithEvasion.value : 0,
+          maxLoadProfileWithEvasion: el.maxLoadProfileWithEvasion ? el.maxLoadProfileWithEvasion.value : 0,
+          expandedEvasionBoarding: el.expandedEvasionBoarding ? el.expandedEvasionBoarding.value : 0,
+          expandedEvasionAlighting: el.expandedEvasionAlighting ? el.expandedEvasionAlighting.value : 0,
+          expandedBoardingPlusExpandedEvasionBoarding: el.expandedBoardingPlusExpandedEvasionBoarding ?
+            el.expandedBoardingPlusExpandedEvasionBoarding.value : 0,
+          expandedAlightingPlusExpandedEvasionAlighting: el.expandedAlightingPlusExpandedEvasionAlighting ?
+            el.expandedAlightingPlusExpandedEvasionAlighting.value : 0,
+          busSaturationWithEvasion: el.busSaturationWithEvasion ? el.busSaturationWithEvasion.value : 0,
           boarding: el.boarding.value,
           boardingWithAlighting: el.boardingWithAlighting.value,
-          passengerWithEvasionPerKmSection: el.passengerWithEvasionPerKmSection.value,
+          passengerWithEvasionPerKmSection: el.passengerWithEvasionPerKmSection ?
+            el.passengerWithEvasionPerKmSection.value : 0,
           capacityPerKmSection: el.capacityPerKmSection.value
         }
       });

--- a/profile/static/profile/js/byExpedition.js
+++ b/profile/static/profile/js/byExpedition.js
@@ -1104,7 +1104,6 @@ $(document).ready(function () {
       app.dataManager(dataManager);
       app.updateCharts(expeditionNumber, boardingWithAlightingPercentage, utilizationCoefficient);
       app.updateDatatable();
-      app.manageEvasionDisplay(showEvasionData);
     } else {
       for (let expeditionId in trips) {
         let trip = trips[expeditionId];
@@ -1187,8 +1186,8 @@ $(document).ready(function () {
       app.dataManager(dataManager);
       app.updateCharts();
       app.updateDatatable();
-      app.manageEvasionDisplay(showEvasionData);
     }
+    app.manageEvasionDisplay(showEvasionData);
   }
 
   // load filters

--- a/profile/static/profile/js/byExpedition.js
+++ b/profile/static/profile/js/byExpedition.js
@@ -963,7 +963,7 @@ $(document).ready(function () {
     /** Hide or show evasion display
      * If show evasion, add evasion legends.
      * If not show evasion, remove evasion global stat column and hide evasion switch.
-     * @param showEvasion: true if show evasion
+     * @param showEvasionData: true if show evasion
      */
     this.manageEvasionDisplay = function (showEvasionData) {
       if (showEvasionData) {
@@ -1030,18 +1030,18 @@ $(document).ready(function () {
           distOnPath: el.pathDistance.hits.hits[0]._source.stopDistanceFromPathStart,
           expeditionNumber: el.doc_count,
           maxLoadProfile: el.maxLoadProfile.value,
-          loadProfileWithEvasion: el.loadProfileWithEvasion ? el.loadProfileWithEvasion.value : 0,
-          maxLoadProfileWithEvasion: el.maxLoadProfileWithEvasion ? el.maxLoadProfileWithEvasion.value : 0,
-          expandedEvasionBoarding: el.expandedEvasionBoarding ? el.expandedEvasionBoarding.value : 0,
-          expandedEvasionAlighting: el.expandedEvasionAlighting ? el.expandedEvasionAlighting.value : 0,
-          expandedBoardingPlusExpandedEvasionBoarding: el.expandedBoardingPlusExpandedEvasionBoarding ?
+          loadProfileWithEvasion: showEvasionData ? el.loadProfileWithEvasion.value : 0,
+          maxLoadProfileWithEvasion: showEvasionData ? el.maxLoadProfileWithEvasion.value : 0,
+          expandedEvasionBoarding: showEvasionData ? el.expandedEvasionBoarding.value : 0,
+          expandedEvasionAlighting: showEvasionData ? el.expandedEvasionAlighting.value : 0,
+          expandedBoardingPlusExpandedEvasionBoarding: showEvasionData ?
             el.expandedBoardingPlusExpandedEvasionBoarding.value : 0,
-          expandedAlightingPlusExpandedEvasionAlighting: el.expandedAlightingPlusExpandedEvasionAlighting ?
+          expandedAlightingPlusExpandedEvasionAlighting: showEvasionData ?
             el.expandedAlightingPlusExpandedEvasionAlighting.value : 0,
-          busSaturationWithEvasion: el.busSaturationWithEvasion ? el.busSaturationWithEvasion.value : 0,
+          busSaturationWithEvasion: showEvasionData ? el.busSaturationWithEvasion.value : 0,
           boarding: el.boarding.value,
           boardingWithAlighting: el.boardingWithAlighting.value,
-          passengerWithEvasionPerKmSection: el.passengerWithEvasionPerKmSection ?
+          passengerWithEvasionPerKmSection: showEvasionData ?
             el.passengerWithEvasionPerKmSection.value : 0,
           capacityPerKmSection: el.capacityPerKmSection.value
         }

--- a/profile/static/profile/js/byExpedition.js
+++ b/profile/static/profile/js/byExpedition.js
@@ -617,7 +617,7 @@ $(document).ready(function () {
       })
     };
 
-    const _updateBarChart = function (showEvasion) {
+    const _updateBarChart = function () {
       let yAxisData = _dataManager.yAxisData();
       let xAxisData = _dataManager.xAxisData();
 
@@ -921,8 +921,8 @@ $(document).ready(function () {
       $("#utilizationCoefficient").html(Number(utilizationCoefficient.toFixed(2)).toLocaleString());
     };
 
-    this.updateCharts = function (expeditionNumber, boardingWithAlightingPercentage, utilizationCoefficient, showEvasion) {
-      _updateBarChart(showEvasion);
+    this.updateCharts = function (expeditionNumber, boardingWithAlightingPercentage, utilizationCoefficient) {
+      _updateBarChart();
       _updateGlobalStats(expeditionNumber, boardingWithAlightingPercentage, utilizationCoefficient);
       _updateMap();
     };
@@ -965,8 +965,8 @@ $(document).ready(function () {
      * If not show evasion, remove evasion global stat column and hide evasion switch.
      * @param showEvasion: true if show evasion
      */
-    this.manageEvasionDisplay = function (showEvasion) {
-      if (showEvasion) {
+    this.manageEvasionDisplay = function (showEvasionData) {
+      if (showEvasionData) {
         let options = {
           legend: {
             data: [
@@ -999,7 +999,7 @@ $(document).ready(function () {
     let busStations = dataSource.busStations;
     let shape = dataSource.shape;
     let dataManager = new DataManager();
-    const showEvasion = dataSource.showEvasion;
+    const showEvasionData = dataSource.showEvasion;
     dataManager.shape(shape);
     if (dataSource.groupedTrips) {
       busStations = dataSource.groupedTrips.aggregations.stop.station.buckets.map(function (el) {
@@ -1102,9 +1102,9 @@ $(document).ready(function () {
       });
       dataManager.xAxisData(tripGroupXAxisData);
       app.dataManager(dataManager);
-      app.updateCharts(expeditionNumber, boardingWithAlightingPercentage, utilizationCoefficient, showEvasion);
+      app.updateCharts(expeditionNumber, boardingWithAlightingPercentage, utilizationCoefficient);
       app.updateDatatable();
-      app.manageEvasionDisplay(showEvasion);
+      app.manageEvasionDisplay(showEvasionData);
     } else {
       for (let expeditionId in trips) {
         let trip = trips[expeditionId];
@@ -1187,7 +1187,7 @@ $(document).ready(function () {
       app.dataManager(dataManager);
       app.updateCharts();
       app.updateDatatable();
-      app.manageEvasionDisplay(showEvasion);
+      app.manageEvasionDisplay(showEvasionData);
     }
   }
 

--- a/profile/views.py
+++ b/profile/views.py
@@ -13,7 +13,7 @@ class LoadProfileByExpeditionHTML(View):
         indicator_table = '''
         <div class="row">
             <div class="col-md-4 col-md-offset-4">
-                <table id="{0}" class="table table-striped table-bordered dt-responsive table-condensed nowrap">
+                <table id="globalStatsTable" style="display:none" class="table table-striped table-bordered dt-responsive table-condensed nowrap">
                     <thead>
                         <tr>
                             <th class="text-center">N° de expediciones</th>


### PR DESCRIPTION
# Cambios en Backend
## Permisos
- Se agrega permiso de evasión en clase **PermissionBuilder** de _localinfo/helper.py_
- Se agrega método estático **has_evasion_permission** a la clase **PermissionBuilder**, esto verifica la existencia del permiso para un usario dado.

## Consultas sin evasión
- Se añade el parámetro _show_evasion_ a las clase **get_base_profile_by_expedition_data_query**. Solo consulta por los datos de evasión en caso de que _show_evasion_ sea verdadero.
- Se añade el parámetro _show_evasion_ a la clase  **get_profile_by_expedition_data**. Solo agrega métricas de evasión al bucket en caso de que _show_evasion_ sea verdadero.
 - Se agregan los test correspondientes

## Vista de Perfil de Carga (clase **LoadProfileByExpeditionData**)
- Se agrega consulta de permiso de ver datos evasión para el usuario que haga llamada a la vista. La respuesta se utiliza para las consultas, para el método **transform_answer**,  para definir cuál clase de exportación se usa en caso de exportar datos y se agrega la respuesta JSON hacia el frontend.
- Se modifica el método **transform_answer** añadiendo el parámetro _show_evasion_. Se separan los componentes de los datos transformados, los datos asociados a evasión se añaden solo en caso de que _show_evasion_ sea verdadero.
- Se corrigen tests.


## Exportar datos
- Se añade nueva clase **ProfileWithoutEvasionCSVHelper** a _csvhelper/helper.py_ para crear un csv sin datos de evasión al momento de exportar datos.
- Se a ñade nueva clase **ProfileByExpeditionWithoutEvasionData** a _csvhelper/profile.py_ para manejar la exportación de datos sin evasión.
- Se agrega la referencia a la nueva clase en _dataDownloader/downloadData.py_ y _datamanager/helper.py_

# Cambios en Frontend
## profile/views.py
- Se añade el estilo _display: none_ a la tabla de estadísticas globales del template. Esto es para que la tabla sea distinta en caso de que se pueda o no ver los datos de evasión
## byExpedition.js
- Se agrega método **manageEvasionDisplay** encargado de ocultar las visualizaciones que muestren información de evasión.
- Se utiliza la variable **showEvasionData** obtenida desde el backend para usar el método **manageEvasionDisplay**  y cambiar los datos inexistentes a 0 en la visualización. Esto último tiene fin de no cambiar la estructura de la solución anterior.
