### PR TITLE
Optimización a Productos Post

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,17 @@ A continuación se describe el proceso de instalación para un entorno de desarr
 
 Este proyecto se encuentra desarrollado en Python 3.7, utilizando el framework web Django, base de datos relacional Postgresql, el motor de análisis de datos Elasticsearch y Redis como base de datos en memoria.
 
-En primer lugar se debe descargar el proyecto desde Github: 
+En primer lugar se debe descargar el proyecto desde Github:
 
-`git clone https://github.com/SmartcitySantiagoChile/fondefVizServer `
+`git clone https://github.com/SmartcitySantiagoChile/fondefVizServer`
 
 #### Requerimientos
 
 ##### Creación de entorno virtual
 
 Para no tener conflictos de dependencias se recomienda hacer uso de un [entorno virtual](https://docs.python.org/3/tutorial/venv.html), este puede ser creado usando la librería [virtualenv](https://virtualenv.pypa.io/en/latest/).
-```
+
+```bash
     # instalar librería virtualenv
     pip install virtualenv
 
@@ -60,7 +61,7 @@ Volver al proyecto:
 
     cd ../
 
-Las librerías necesarias para ejecutar el proyecto están definidas en el archivo `requirements.txt` 
+Las librerías necesarias para ejecutar el proyecto están definidas en el archivo `requirements.txt`
 ubicado en la raíz del proyecto y se pueden instalar rápidamente con el comando `pip install -r requirements.txt`.
 
 ##### Postgresql
@@ -69,23 +70,23 @@ La base de datos relacional es utilizada para el almacenamiento de datos asociad
 
 La descarga e instalación se puede realizar siguiendo los pasos del siguiente enlace:
 
->https://www.postgresql.org/download/
+><https://www.postgresql.org/download/>
 
-##### Elasticsearch (versión: 6.2.3)
+##### Elasticsearch (versión: 6.4.2)
 
 Los datos generados por ADATRAP son almacenados en una (o más) instancia(s) de elasticsearch. Es importante tener en cuenta que es necesario contar con una versión de Java para su ejecución. Se recomienda instalar una versión de [openJDK 8](https://openjdk.java.net/install/) para su ejecución (solo disponible para ambientes Linux), para entornos con sistema operativo (S.O) Windows se recomienda descargar desde la [página oficial](https://www.oracle.com/technetwork/java/javase/downloads/index.html) de Oracle.
 
 Habiendo instalado JDK se procede instalar Elasticsearch, se puede descargar desde el siguiente enlace:
->https://www.elastic.co/es/downloads/past-releases/elasticsearch-6-2-3
+><https://www.elastic.co/es/downloads/past-releases/elasticsearch-6-2-3>
 
 ##### Redis
 
 La base de datos en memoria principal (RAM) es utilizada en algunos procesos que requieren la ejecución de tareas asíncronas, como lo puede ser el proceso para exportar datos, envío de correos eléctronicos o la carga de datos.
 
 Redis puede ser descargado desde el siguiente enlace:
->https://redis.io/download
+><https://redis.io/download>
 
-Opcionalmente (pero muy recomendable) conviene instalar `redis-tools` para tener un mayor control y monitoreo de Redis ya que permite inspeccionar los datos almacenados o su [comportamiento en tiempo real](https://redis.io/commands/MONITOR). Esta herramienta se puede instalar en Ubuntu ejecutando el siguiente comando: 
+Opcionalmente (pero muy recomendable) conviene instalar `redis-tools` para tener un mayor control y monitoreo de Redis ya que permite inspeccionar los datos almacenados o su [comportamiento en tiempo real](https://redis.io/commands/MONITOR). Esta herramienta se puede instalar en Ubuntu ejecutando el siguiente comando:
 
     sudo apt install redis-tools
 
@@ -93,7 +94,7 @@ Opcionalmente (pero muy recomendable) conviene instalar `redis-tools` para tener
 
 La administración de las librerías `Javascript` (usadas por la página web) son administradas por Bower, herramienta que requiere tener instalado el gestor de paquetes npm:
 
->https://www.npmjs.com/get-npm
+><https://www.npmjs.com/get-npm>
 
 Luego de la instalación de npm se procede a instalar Bower.
 
@@ -116,7 +117,7 @@ Se requiere crear la base de datos relacional del proyecto, por lo que crearemos
 ```
 
 #### .env
-    
+
 Se debe crear un archivo .env en la raíz del proyecto con fin de mantener encapsuladas las variables utilizadas por `settings.py` de Django, esto se realiza porque estos valores cambian dependiendo del entorno en que se esté ejecutando la plataforma (desarrollo o producción).
 
 El archivo .env contiene las siguientes definiciones:
@@ -171,15 +172,14 @@ El archivo .env contiene las siguientes definiciones:
     # Configuraciones de Amazon Web Service
     AWS_ACCESS_KEY_ID=
     AWS_SECRET_ACCESS_KEY=
-   
 
 Estos datos se dividen en las siguientes secciones:
 
-
 ##### Configuraciones generales de Django
-* SECRET_KEY: string que representa una semilla en python para seguridad.                     
+
+* SECRET_KEY: string que representa una semilla en python para seguridad.
 * DEBUG: ejecutar la aplicación en modo debug (TRUE/FALSE).
-* ALLOWED_HOSTS: conexiones permitidas para el ingreso a la aplicación.                                   
+* ALLOWED_HOSTS: conexiones permitidas para el ingreso a la aplicación.
 * INTERNAL_IPS: conexiones que mostraran la debug toolbar y debug panel
 * URL_PREFIX:
 * DOWNLOAD_PATH: path de descarga para archivos manipulados por redis
@@ -197,15 +197,14 @@ Estos datos se dividen en las siguientes secciones:
 * ELASTICSEARCH_HOST: host de elasticsearch
 * ELASTICSEARCH_PORT: puerto de elasticsearch
 
-
 ##### Configuraciones de Redis
 
 * REDIS_HOST: host de redis
 * REDIS_PORT: puerto de redis
 * REDIS_DB: nombre de la base de datos de redis
 
-
 ##### Configuraciones de email
+
 * EMAIL_HOST:
 * EMAIL_PORT:
 * EMAIL_USE_TLS:
@@ -213,8 +212,8 @@ Estos datos se dividen en las siguientes secciones:
 * EMAIL_HOST_PASSWORD:
 * SERVER_EMAIL:
 
-
 ##### Configuraciones de buckets para almacenamiento de datos en S3
+
 * GPS_BUCKET_NAME:
 * OP_PROGRAM_BUCKET_NAME:
 * FILE_196_BUCKET_NAME:
@@ -223,38 +222,36 @@ Estos datos se dividen en las siguientes secciones:
 * SPEED_BUCKET_NAME:
 * TRANSACTION_BUCKET_NAME:
 * TRIP_BUCKET_NAME:
-* REPRESENTATIVE_WEEk_BUCKET_NAME: 
-
+* REPRESENTATIVE_WEEk_BUCKET_NAME:
 
 ##### Configuraciones de Amazon Web Service
+
 * AWS_ACCESS_KEY_ID:
 * AWS_SECRET_ACCESS_KEY:
 
 #### Logs
 
-En el directorio `/fondefVizServer/logs` hay que crear un archivo `file.log` con fin de mantener registros de la 
-aplicación. 
-
+En el directorio `/fondefVizServer/logs` hay que crear un archivo `file.log` con fin de mantener registros de la
+aplicación.
 
 #### Modelos y Usuarios de Django
 
 Para crear las tablas en la base de datos se deben ejecutar las migraciones de Django ejecutando el siguiente
 comando:
 
-    $ python manage.py migrate
+    python manage.py migrate
 
 Luego se deben cargar los datos base requeridos por la aplicación web, para esto se debe ejecutar la siguiente instrucción:
 
-    $ python manage.py loaddata datasource communes daytypes halfhours operators timeperioddates timeperiods transportmodes
+    python manage.py loaddata datasource communes daytypes halfhours operators timeperioddates timeperiods transportmodes
 
 La interfaz web requiere de un usuario para acceder por loq que se debe crear un super usuario, esto se hace por medio del comando:
-    
-    $ python manage.py createsuperuser
 
+    python manage.py createsuperuser
 
 Se debe ejecutar django_js_reverse para el manejo de las urls en los archivos js:
 
-    $ python manage.py collectstatic_js_reverse
+    python manage.py collectstatic_js_reverse
 
 Se debe actualizar el submódulo de los rqworkers que ejecutarán los procesos segundo plano:
 
@@ -266,61 +263,55 @@ Finalmente hay que instalar las dependencias js y css con bower.
 
     bower install
 
-    
-### Ejecución de la aplicación 
+### Ejecución de la aplicación
 
-#### Servicios complementarios 
+#### Servicios complementarios
 
 Para el correcto funcionamiento de la aplicación se deben ejecutar los siguientes
 servicios:
 
 Se debe ejecutar el servicio de búsquedas Elasticsearch:
 
-    $ ./elasticsearch-6.2.3/bin/elasticsearch
-
+    ./elasticsearch-6.4.2/bin/elasticsearch
 
 Se deben crear los índices para Elasticsearch para ello ejecutamos el siguiente comando:
 
-    $ python manage.py createindexes
-
+    python manage.py createindexes
 
 Se debe ejecutar Redis para el servicio de procesos en segundo plano.
- 
-    $ ./redis-5.0.7/src/redis-server
+
+    ./redis-5.0.7/src/redis-server
 
 Para ejecutar los procesos en segundo plano de la aplicación, se deben dejar corriendo los rqworkers con
 el siguiente comando:
 
-    $ python manage.py rqworker count_lines data_exporter data_uploader
-   
+    python manage.py rqworker count_lines data_exporter data_uploader
+
 Finalmente se debe ejecutar la aplicación Django:
 
-    $ python manage.py runserver
-   
+    python manage.py runserver
 
 ![AAdatrap](readme_data/adatrap.png)
-
 
 ### Carga de Datos
 
 Para realizar la carga de datos se requiere la ejecución de al menos un rqworker para cada tipo:
 
-    $ python manage.py rqworker count_lines data_exporter data_uploader
+    python manage.py rqworker count_lines data_exporter data_uploader
 
-Ingresando a la aplicación, se debe ir a la sección de Administración, Fuentes de datos. 
+Ingresando a la aplicación, se debe ir a la sección de Administración, Fuentes de datos.
 En esta sección deben modificar los directorios de los archivos a cargar:
 
 ![Fuentes de Carga](readme_data/fuente_datos.png)
 
-Posteriormente se debe ejecutar el comando `searchfiles.py`, el cual se encargará de buscar 
+Posteriormente se debe ejecutar el comando `searchfiles.py`, el cual se encargará de buscar
 los archivos en los directorios modificados anteriormente e ingresarlos a la tabla para su posterior carga.
 Por lo que ejecutamos:
 
-    $ python manage.py searchfiles
- 
+    python manage.py searchfiles
+
 Esto permitirá la visualización de los datos en la sección Administración, Carga de datos.
 En esta sección debe seleccionar la opción "cargar datos" para cada uno de los archivos.
-
 
 ![Carga de Datos](readme_data/carga_datos.png)
 
@@ -330,6 +321,7 @@ de la aplicación:
 ![Perfil_de_Carga](readme_data/perfil_carga.png)
 
 ### Docker
+
 Docker es una tecnología que permite trabajar en ambientes controlados, aislados del resto de librerías del sistema operativo y operan bajo una lógica sin estado (stateless).
 
 Para crear la imagen docker y ejecutarla se utilizan los siguientes comandos:
@@ -341,7 +333,6 @@ Construir imagen:
 Antes de ejecutar la imagen es necesario aumentar la memoria virtual para el servicio de elasticsearch:
 
 `sysctl -w vm.max_map_count=262144`
-
 
 Ejecutar:
 
@@ -356,13 +347,14 @@ esto con fin de evitar que siga ejecutándose el ambiente de pruebas posterior a
 
 Construir la imagen:
 
-`docker-compose -f docker/docker-compose-test.yml build ` 
+`docker-compose -f docker/docker-compose-test.yml build`
 
 Ejecutar tests:
- 
-`docker-compose -f docker/docker-compose-test.yml up --abort-on-container-exit` 
+
+`docker-compose -f docker/docker-compose-test.yml up --abort-on-container-exit`
 
 ### Actualizar dataUploader
+
 Cada vez que exista una nueva release de dataUploader se debe actualizar la versión del submódulo del proyecto. Desde la raíz del proyecto se debe direccionar al módulo dataUploader:
 
     cd dataUploader
@@ -387,15 +379,17 @@ Finalmente actualizar vía pip
 ### Opcionales
 
 #### Monitorear RQworkers
+
 Se puede monitorear los workers utilizando el cliente de redis por medio de los siguientes comandos:
 
-    $ ./redis-5.0.7/src/redis-cli
-    $ monitor
-    
+    ./redis-5.0.7/src/redis-cli
+    monitor
+
 #### Monitorear Elasticsearch
+
 Para monitoriar el funcionamiento de Elasticsearch se puede utilizar Cerebro, el cuál se puede descargar en el siguiente enlace:
 
->https://github.com/lmenezes/cerebro
+><https://github.com/lmenezes/cerebro>
 
 Posteriormente se debe ejecutar cerebro:
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ La descarga e instalación se puede realizar siguiendo los pasos del siguiente e
 Los datos generados por ADATRAP son almacenados en una (o más) instancia(s) de elasticsearch. Es importante tener en cuenta que es necesario contar con una versión de Java para su ejecución. Se recomienda instalar una versión de [openJDK 8](https://openjdk.java.net/install/) para su ejecución (solo disponible para ambientes Linux), para entornos con sistema operativo (S.O) Windows se recomienda descargar desde la [página oficial](https://www.oracle.com/technetwork/java/javase/downloads/index.html) de Oracle.
 
 Habiendo instalado JDK se procede instalar Elasticsearch, se puede descargar desde el siguiente enlace:
-><https://www.elastic.co/es/downloads/past-releases/elasticsearch-6-2-3>
+><https://www.elastic.co/es/downloads/past-releases/elasticsearch-6-4-2>
 
 ##### Redis
 

--- a/dataDownloader/csvhelper/helper.py
+++ b/dataDownloader/csvhelper/helper.py
@@ -1,9 +1,9 @@
 import csv
-from datetime import datetime
 import os
 import uuid
 import zipfile
 from collections import defaultdict
+from datetime import datetime
 
 from django.utils.dateparse import parse_date
 from elasticsearch_dsl import A, Search
@@ -19,14 +19,12 @@ from esapi.helper.stage import ESStageHelper
 from esapi.helper.stop import ESStopHelper
 from esapi.helper.stopbyroute import ESStopByRouteHelper
 from esapi.helper.trip import ESTripHelper
-from localinfo.helper import (
-    get_day_type_list_for_select_input,
-    get_timeperiod_list_for_select_input,
-    get_operator_list_for_select_input,
-    get_halfhour_list_for_select_input,
-    get_commune_list_for_select_input,
-    get_transport_mode_list_for_select_input,
-)
+from localinfo.helper import (get_commune_list_for_select_input,
+                              get_day_type_list_for_select_input,
+                              get_halfhour_list_for_select_input,
+                              get_operator_list_for_select_input,
+                              get_timeperiod_list_for_select_input,
+                              get_transport_mode_list_for_select_input)
 
 README_FILE_NAME = "Léeme.txt"
 
@@ -1967,7 +1965,7 @@ class PostProductsStageTransferInPeriodCSVHelper(CSVHelper):
             {'boardingStopCommune': A('terms', field='boardingStopCommune', missing_bucket=True)},
             {'authStopCode': A('terms', field='authStopCode', missing_bucket=True)},
             {'halfHourInBoardingTime': A('terms', field='halfHourInBoardingTime', missing_bucket=True)},
-        ], size=100)
+        ], size=1000)
 
         while True:
             # Use the existing es_query for the composite aggregation
@@ -2018,8 +2016,9 @@ class PostProductsStageTransferInPeriodCSVHelper(CSVHelper):
             },
             {
                 "es_name": "boardingStopCommune",
-                "csv_name": "Comuna_origen",
-                "definition": "Comuna de inicio del viaje",
+                "csv_name": "Comuna_subida",
+                "definition": "Comuna asociada a la parada de subida de la primera etapa del viaje",
+                
             },
             {
                 "es_name": "authStopCode",
@@ -2086,7 +2085,7 @@ class PostProductsStageTransferInPeriodGroupedByDateCSVHelper(CSVHelper):
             {'boardingStopCommune': A('terms', field='boardingStopCommune', missing_bucket=True)},
             {'authStopCode': A('terms', field='authStopCode', missing_bucket=True)},
             {'halfHourInBoardingTime': A('terms', field='halfHourInBoardingTime', missing_bucket=True)},
-        ], size=100)
+        ], size=1000)
 
         # Initial after_key is None
         after_key = None
@@ -2121,13 +2120,18 @@ class PostProductsStageTransferInPeriodGroupedByDateCSVHelper(CSVHelper):
                 "csv_name": "Fecha",
                 "definition": "Fecha de la consulta",
             },
-            
             {
                 "es_name": "dayType",
                 "csv_name": "Tipo_día",
                 "definition": "tipo de día en el que inició el viaje",
             },
-              {
+            {
+                "es_name": "boardingStopCommune",
+                "csv_name": "Comuna_subida",
+                "definition": "Comuna asociada a la parada de subida de la primera etapa del viaje",
+                
+            },
+            {
                 "es_name": "authStopCode",
                 "csv_name": "Parada_subida",
                 "definition": "Código transantiago de la parada donde inició el viaje",

--- a/dataDownloader/csvhelper/helper.py
+++ b/dataDownloader/csvhelper/helper.py
@@ -1062,11 +1062,10 @@ class TripCSVHelper(CSVHelper):
                 "es_name": "distancia_ruta",
                 "csv_name": "Distancia_considerando_ruta",
                 "definition": "distancia considerando la ruta de los modos utilizados durante el viaje",
-            },
-            {
-                "es_name": "tiempo_subida",
-                "csv_name": "Tiempo_subida",
-                "definition": "Fecha y hora en que se inició el viaje",
+            }, {
+                "es_name": "date",
+                "csv_name": "Fecha",
+                "definition": "Día en que inició la etapa",
             },
             {
                 "es_name": "tiempo_bajada",
@@ -2116,9 +2115,9 @@ class PostProductsStageTransferInPeriodGroupedByDateCSVHelper(CSVHelper):
     def get_column_dict(self):
         return [
             {
-                "es_name": "fecha",
+                "es_name": "date",
                 "csv_name": "Fecha",
-                "definition": "Fecha de la consulta",
+                "definition": "Día en que inició la etapa",
             },
             {
                 "es_name": "dayType",

--- a/dataDownloader/csvhelper/helper.py
+++ b/dataDownloader/csvhelper/helper.py
@@ -2051,9 +2051,10 @@ class PostProductsStageTransferInPeriodCSVHelper(CSVHelper):
     def row_parser(self, row):
         day_type = self.day_type_dict[row.key.dayType]
         half_hour = self.halfhour_dict[row.key.halfHourInBoardingTime]
+        commune = self.commune_dict[row.key.boardingStopCommune]
         row = [
             day_type,
-            row.key.boardingStopCommune,
+            commune,
             row.key.authStopCode,
             half_hour,
             str(row.doc_count),

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - database_network
       - elastic
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.2
     ulimits:
       memlock:
         soft: -1

--- a/esapi/helper/stage.py
+++ b/esapi/helper/stage.py
@@ -57,7 +57,7 @@ class ESStageHelper(ElasticSearchHelper):
 
         return es_query
 
-    def get_post_products_transfers_data_query(self, dates, day_types, communes, size=100):
+    def get_post_products_transfers_data_query(self, dates, day_types, communes, size=10000):
         es_query = self.get_transfers_base_query(dates, day_types, communes)
 
         es_query = es_query.filter('range', stageNumber={'gt': 1})
@@ -73,7 +73,7 @@ class ESStageHelper(ElasticSearchHelper):
 
         return es_query
 
-    def get_post_products_aggregated_transfers_data_query(self, dates, day_types, communes,  size=100):
+    def get_post_products_aggregated_transfers_data_query(self, dates, day_types, communes,  size=10000):
         es_query = self.get_transfers_base_query(dates, day_types, communes)
 
         es_query = es_query.filter('range', stageNumber={'gt': 1})

--- a/esapi/helper/stage.py
+++ b/esapi/helper/stage.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from functools import reduce
 
-from elasticsearch_dsl import A
+from elasticsearch_dsl import A, DateHistogramFacet
 from elasticsearch_dsl.query import Q
 
 from esapi.errors import ESQueryDateRangeParametersDoesNotExist
@@ -57,7 +57,7 @@ class ESStageHelper(ElasticSearchHelper):
 
         return es_query
 
-    def get_post_products_transfers_data_query(self, dates, day_types, communes, size=100, after_key = None):
+    def get_post_products_transfers_data_query(self, dates, day_types, communes, size=100):
         es_query = self.get_transfers_base_query(dates, day_types, communes)
 
         # Filter rows when stage value is greater than 1
@@ -71,25 +71,28 @@ class ESStageHelper(ElasticSearchHelper):
             {'halfHourInBoardingTime': A('terms', field='halfHourInBoardingTime', missing_bucket=True)},
         ], size=size)
 
-        # Add the Composite Aggregation to the search object
+        # Add the Composite Aggregation to the es_query
         es_query.aggs.bucket('result', composite_agg).metric('expandedBoarding', 'avg', field='expandedBoarding')
 
         return es_query
 
-    def get_post_products_aggregated_transfers_data_query(self, dates, day_types, communes):
+    def get_post_products_aggregated_transfers_data_query(self, dates, day_types, communes,  size=100):
         es_query = self.get_transfers_base_query(dates, day_types, communes)
 
         # it uses only rows when stage value is greater than 1
         es_query = es_query.filter('range', stageNumber={'gt': 1})
 
-        bucket_name = 'result'
-        es_query.aggs.bucket(bucket_name, 'date_histogram', field='boardingTime', interval='day'). \
-            bucket('dayType', 'terms', field='dayType', size=4). \
-            bucket('boardingStopCommune', 'terms', field='boardingStopCommune', size=48). \
-            bucket('authStopCode', 'terms', field='authStopCode', size=13000). \
-            bucket('halfHourInBoardingTime', 'terms', field='halfHourInBoardingTime', size=48). \
-            metric('expandedBoarding', 'avg', field='expandedBoarding')
+        # Define the Composite Aggregation
+        composite_agg = A('composite', sources=[
+            {'boardingTime': A('date_histogram', field='boardingTime', interval='day')},
+            {'dayType': A('terms', field='dayType', missing_bucket=True)},
+            {'boardingStopCommune': A('terms', field='boardingStopCommune', missing_bucket=True)},
+            {'authStopCode': A('terms', field='authStopCode', missing_bucket=True)},
+            {'halfHourInBoardingTime': A('terms', field='halfHourInBoardingTime', missing_bucket=True)},
+        ], size=size)
 
+        # Add the Composite Aggregation to the es_query
+        es_query.aggs.bucket('result', composite_agg).metric('expandedBoarding', 'avg', field='expandedBoarding')
         return es_query
 
     def get_post_products_aggregated_transfers_data_by_operator_query(self, dates, day_types):

--- a/esapi/helper/stage.py
+++ b/esapi/helper/stage.py
@@ -57,7 +57,7 @@ class ESStageHelper(ElasticSearchHelper):
 
         return es_query
 
-    def get_post_products_transfers_data_query(self, dates, day_types, communes, size=10000):
+    def get_post_products_transfers_data_query(self, dates, day_types, communes, size=1000):
         es_query = self.get_transfers_base_query(dates, day_types, communes)
 
         es_query = es_query.filter('range', stageNumber={'gt': 1})
@@ -73,7 +73,7 @@ class ESStageHelper(ElasticSearchHelper):
 
         return es_query
 
-    def get_post_products_aggregated_transfers_data_query(self, dates, day_types, communes,  size=10000):
+    def get_post_products_aggregated_transfers_data_query(self, dates, day_types, communes,  size=1000):
         es_query = self.get_transfers_base_query(dates, day_types, communes)
 
         es_query = es_query.filter('range', stageNumber={'gt': 1})

--- a/esapi/helper/stage.py
+++ b/esapi/helper/stage.py
@@ -60,18 +60,15 @@ class ESStageHelper(ElasticSearchHelper):
     def get_post_products_transfers_data_query(self, dates, day_types, communes, size=100):
         es_query = self.get_transfers_base_query(dates, day_types, communes)
 
-        # Filter rows when stage value is greater than 1
         es_query = es_query.filter('range', stageNumber={'gt': 1})
 
-        # Define the Composite Aggregation
         composite_agg = A('composite', sources=[
             {'dayType': A('terms', field='dayType', missing_bucket=True)},
             {'boardingStopCommune': A('terms', field='boardingStopCommune', missing_bucket=True)},
             {'authStopCode': A('terms', field='authStopCode', missing_bucket=True)},
             {'halfHourInBoardingTime': A('terms', field='halfHourInBoardingTime', missing_bucket=True)},
         ], size=size)
-                                                                                                                                                                                                                                                                                                                                        
-        # Add the Composite Aggregation to the es_query
+
         es_query.aggs.bucket('result', composite_agg).metric('expandedBoarding', 'avg', field='expandedBoarding')
 
         return es_query
@@ -79,10 +76,8 @@ class ESStageHelper(ElasticSearchHelper):
     def get_post_products_aggregated_transfers_data_query(self, dates, day_types, communes,  size=100):
         es_query = self.get_transfers_base_query(dates, day_types, communes)
 
-        # it uses only rows when stage value is greater than 1
         es_query = es_query.filter('range', stageNumber={'gt': 1})
 
-        # Define the Composite Aggregation
         composite_agg = A('composite', sources=[
             {'boardingTime': A('date_histogram', field='boardingTime', interval='day')},
             {'dayType': A('terms', field='dayType', missing_bucket=True)},
@@ -91,7 +86,6 @@ class ESStageHelper(ElasticSearchHelper):
             {'halfHourInBoardingTime': A('terms', field='halfHourInBoardingTime', missing_bucket=True)},
         ], size=size)
 
-        # Add the Composite Aggregation to the es_query
         es_query.aggs.bucket('result', composite_agg).metric('expandedBoarding', 'avg', field='expandedBoarding')
         return es_query
 

--- a/esapi/helper/stage.py
+++ b/esapi/helper/stage.py
@@ -70,7 +70,7 @@ class ESStageHelper(ElasticSearchHelper):
             {'authStopCode': A('terms', field='authStopCode', missing_bucket=True)},
             {'halfHourInBoardingTime': A('terms', field='halfHourInBoardingTime', missing_bucket=True)},
         ], size=size)
-
+                                                                                                                                                                                                                                                                                                                                        
         # Add the Composite Aggregation to the es_query
         es_query.aggs.bucket('result', composite_agg).metric('expandedBoarding', 'avg', field='expandedBoarding')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ python-coveralls==2.9.3
 python-decouple==3.8
 redis==4.5.3
 rq==1.12.0
+
 ./dataUploader/

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,4 @@ python-coveralls==2.9.3
 python-decouple==3.8
 redis==4.5.3
 rq==1.12.0
-
 ./dataUploader/

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-debug-toolbar==3.8.1
 django-debug-panel==0.8.3
 django-crontab==0.7.1
 elasticsearch==6.3.1
-elasticsearch-dsl==6.3.1
+elasticsearch-dsl==6.4.0
 fakeredis==2.10.2
 gunicorn==20.1.0
 openpyxl==3.1.2


### PR DESCRIPTION
# Contexto
Las consultas de productos post "Transbordos por paradas" generan un uso elevado de memoria, colgando la instancia de Elasticsearch cuando se consultan varios días.

# 🗂 Correcciones de Consultas Productos Post
- Se corrige la consulta `get_post_products_transfers_data_query` y `get_post_products_aggregated_transfers_data_query` utilizando [Composite Aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html) . Por defecto se utilizan páginas de 1000 datos.
- Se actualizan parsers de estas consultas en `dataDownloader/csvhelper/helper.py`

# ⬆ Actualización de versión de Elasticsearch
- Se actualiza la versión de Elasticsearch en `README.md`, `docker-compose.yml`.
- Se actualiza la versión de elasticsearch-dsl para permitir el uso de `composite aggregations`.

# Que revisar
- Realizar consultas para ambos productos post.